### PR TITLE
Local tunnel

### DIFF
--- a/bin/mysql-sync
+++ b/bin/mysql-sync
@@ -1,0 +1,415 @@
+#!/usr/bin/php
+
+<?php
+
+/**
+ * Usage:
+ * Example:
+ * mysql-sync root:password@localhost:3308/voeb root:password@localhost:3306/v json|verbose
+ */
+
+mb_internal_encoding("UTF-8");
+
+// print_r($argv);
+
+if(!isset($argv[0]) || !isset($argv[1]) || !isset($argv[2]))
+{
+    echo "Usage: mysql-sync root:password@localhost:port/source_db root:password@localhost:port/dest_db verbose";
+    exit;
+}
+
+$source = parseDSN('dsn://' . $argv[1]);
+$dest = parseDSN('dsn://' . $argv[2]);
+
+$output = 'n';
+
+if(isset($argv[3]) && $argv[3] == 'json') $output = 'j';
+if (isset($argv[3]) && $argv[3] == 'verbose') $output = 'v';
+
+if($source['database'] === $dest['database'])
+{
+    echo "There is currently a bug in percona and it does sync databases when they have the same name. Please use different database names";
+    exit(1);
+}
+
+// validate
+checkConnection($source);
+checkConnection($dest);
+checkNBTables($source, $dest);
+checkSchema($source, $dest);
+
+
+// sync
+sync($source, $dest, $output);
+
+exit;
+
+function sync($source, $dest, $output)
+{
+    $tables = getTablesOutOfSync($source, $dest);
+
+// sync
+    $table_out = array();
+    foreach ($tables as $table)
+    {
+
+	$dir = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'percona' . DIRECTORY_SEPARATOR;
+        $cmd = $dir . 'pt-table-sync --print --verbose --function MD5 --execute h=' . $source['hostspec'] . ',u=' . $source['username'] . ',p=' . $source['password'] . ',D=' . $source['database'] . ',t=' . $table . ',P=' . $source['port'] . ' h=' . $dest['hostspec'] . ',u=' . $dest['username'] . ',p=' . $dest['password'] . ',D=' . $dest['database'] . ',t=' . $table . ',P=' . $dest['port'];
+	
+	$out = run_cmd($cmd);
+
+	preg_match_all('#(INSERT INTO|UPDATE|DELETE FROM|REPLACE)(.*?)\ \/\*#', $out, $rows);
+
+        $table_out['data'][$table] = $rows[0];
+        $table_out['synced'][$table] = $table." (".count($rows[0]).")";
+	if ($output == 'v') {
+		echo "Sync of:".$table." - ";
+		print_r ($table_out['data'][$table]);
+	}
+    
+    }
+    if(isset($table_out['synced']) && ($output == 'v' || $output == 'n')) { 
+	echo "Synced tables - \n";
+	print_r ($table_out['synced']);
+    }
+    $table_out['un-synced'] = getTablesOutOfSync($source, $dest);
+    if ($output == 'v' || $output == 'n') {
+	if($table_out['un-synced']){
+		echo "Tables still out of sync\n";
+		print_r($table_out['un-synced']);
+	}else{
+		echo "All Tables synced\n\n";
+	}
+    }
+    if ($output == 'j') {
+        ob_start();
+	echo json_encode($table_out);
+	ob_flush();
+    }
+}
+
+/**
+ * returns list of tables in the destination that are out of sync with the source
+ * @param type $source
+ * @param type $dest
+ * @return type
+ */
+function getTablesOutOfSync($source, $dest)
+{
+    $sSum = getTablesChecksum($source);
+    $dSum = getTablesChecksum($dest);
+
+    $ret = array();
+    foreach (getTables($source) as $name)
+    {
+        if ($sSum[$name] !== $dSum[$name])
+        {
+            $ret[] = $name;
+        }
+    }
+
+    return $ret;
+}
+
+/**
+ * return map with table_name => checksum
+ * @param type $info
+ * @return type
+ */
+function getTablesChecksum($info)
+{
+    $args = convertToMySQLArgs($info);
+    $tables = getTables($info);
+
+    $ret = array();
+    foreach ($tables as $table)
+    {
+        $out = run_cmd("mysql $args -e 'checksum table `$table`;'");
+        $matches = array();
+        preg_match('/\d+/', $out, $matches);
+        $ret[$table] = array_pop($matches);
+    }
+
+    return $ret;
+}
+
+/**
+ * checks number of tables is the same in both databases
+ * @param type $source
+ * @param type $dest
+ */
+function checkNBTables($source, $dest)
+{
+    if (count(getTables($source)) !== count(getTables($dest)))
+    {
+        echo "Not the same number of tables in both databases";
+        exit(1);
+    }
+}
+
+/**
+ * check schema description is the same in both databases
+ * @param type $source
+ * @param type $dest
+ */
+function checkSchema($source, $dest)
+{
+    if (getDBSchemaChecksum($source) !== getDBSchemaChecksum($dest))
+    {
+        echo "Table descriptions are not similar";
+
+        // provide helpful error message
+        $sourceDescriptions = getTableDescriptions($source);
+        $destDescriptions = getTableDescriptions($dest);
+
+        foreach (getTables($source) as $name)
+        {
+            if (sha1($sourceDescriptions[$name]) !== sha1($destDescriptions[$name]))
+            {
+                echo "\n\nInvalid table: $name";
+            }
+        }
+        exit(1);
+    }
+}
+
+/**
+ * return map of table_name => description
+ * @param type $info
+ * @return type
+ */
+function getTableDescriptions($info)
+{
+    $args = convertToMySQLArgs($info);
+    $tables = getTables($info);
+
+    $ret = array();
+    foreach ($tables as $table)
+    {
+        $ret[$table] = run_cmd("mysql $args -e 'describe `$table`;'");
+    }
+
+    return $ret;
+}
+
+/**
+ * returns checksum based on all descriptions
+ * @param type $info
+ * @return type
+ */
+function getDBSchemaChecksum($info)
+{
+    $tables = getTableDescriptions($info);
+    return sha1(implode(' ', $tables));
+}
+
+/**
+ * list of tables
+ * @param type $info
+ * @return type
+ */
+function getTables($info)
+{
+    $sargs = convertToMySQLArgs($info);
+    $cmd = "mysql $sargs -e 'use information_schema;select TABLE_NAME from TABLES where TABLE_SCHEMA = \"" . $info['database'] . "\"'";
+    $tables = split_newlines(run_cmd($cmd));
+
+    array_pop($tables);
+    array_shift($tables);
+
+    return $tables;
+}
+
+function convertToMySQLArgs($info)
+{
+    $ret = '--user=' . $info['username'] . ' --password=' . $info['password'] . ' --protocol=TCP --host=' . $info['hostspec'] . ' --port=' . $info['port'] . ' --database=' . $info['database'];
+    $ret = ' --port=' . $info['port'] . ' --database=' . $info['database'];
+
+    return $ret;
+}
+
+function checkConnection($info)
+{
+    $mysqlArgs = convertToMySQLArgs($info);
+    ob_start();
+    $cmd = "mysql $mysqlArgs -e 'show tables;'";
+    $ret = 0;
+    system($cmd, $ret);
+    ob_end_clean();
+
+    if ($ret === 1)
+    {
+        echo "cannot establish connection using: \n $cmd";
+        exit(1);
+    }
+}
+
+function parseDSN($dsn)
+{
+    $parsed = array(
+        'phptype' => false,
+        'dbsyntax' => false,
+        'username' => false,
+        'password' => false,
+        'protocol' => false,
+        'hostspec' => false,
+        'port' => false,
+        'socket' => false,
+        'database' => false,
+    );
+
+    if (is_array($dsn))
+    {
+        $dsn = array_merge($parsed, $dsn);
+        if (!$dsn['dbsyntax'])
+        {
+            $dsn['dbsyntax'] = $dsn['phptype'];
+        }
+        return $dsn;
+    }
+
+    // Find phptype and dbsyntax
+    if (($pos = strpos($dsn, '://')) !== false)
+    {
+        $str = substr($dsn, 0, $pos);
+        $dsn = substr($dsn, $pos + 3);
+    }
+    else
+    {
+        $str = $dsn;
+        $dsn = null;
+    }
+
+    // Get phptype and dbsyntax
+    // $str => phptype(dbsyntax)
+    if (preg_match('|^(.+?)\((.*?)\)$|', $str, $arr))
+    {
+        $parsed['phptype'] = $arr[1];
+        $parsed['dbsyntax'] = !$arr[2] ? $arr[1] : $arr[2];
+    }
+    else
+    {
+        $parsed['phptype'] = $str;
+        $parsed['dbsyntax'] = $str;
+    }
+
+    if (!count($dsn))
+    {
+        return $parsed;
+    }
+
+    // Get (if found): username and password
+    // $dsn => username:password@protocol+hostspec/database
+    if (($at = strrpos($dsn, '@')) !== false)
+    {
+        $str = substr($dsn, 0, $at);
+        $dsn = substr($dsn, $at + 1);
+        if (($pos = strpos($str, ':')) !== false)
+        {
+            $parsed['username'] = rawurldecode(substr($str, 0, $pos));
+            $parsed['password'] = rawurldecode(substr($str, $pos + 1));
+        }
+        else
+        {
+            $parsed['username'] = rawurldecode($str);
+        }
+    }
+
+    // Find protocol and hostspec
+
+    if (preg_match('|^([^(]+)\((.*?)\)/?(.*?)$|', $dsn, $match))
+    {
+        // $dsn => proto(proto_opts)/database
+        $proto = $match[1];
+        $proto_opts = $match[2] ? $match[2] : false;
+        $dsn = $match[3];
+    }
+    else
+    {
+        // $dsn => protocol+hostspec/database (old format)
+        if (strpos($dsn, '+') !== false)
+        {
+            list($proto, $dsn) = explode('+', $dsn, 2);
+        }
+        if (strpos($dsn, '/') !== false)
+        {
+            list($proto_opts, $dsn) = explode('/', $dsn, 2);
+        }
+        else
+        {
+            $proto_opts = $dsn;
+            $dsn = null;
+        }
+    }
+
+    // process the different protocol options
+    $parsed['protocol'] = (!empty($proto)) ? $proto : 'tcp';
+    $proto_opts = rawurldecode($proto_opts);
+    if ($parsed['protocol'] == 'tcp')
+    {
+        if (strpos($proto_opts, ':') !== false)
+        {
+            list($parsed['hostspec'],
+                    $parsed['port']) = explode(':', $proto_opts);
+        }
+        else
+        {
+            $parsed['hostspec'] = $proto_opts;
+        }
+    }
+    elseif ($parsed['protocol'] == 'unix')
+    {
+        $parsed['socket'] = $proto_opts;
+    }
+
+    // Get dabase if any
+    // $dsn => database
+    if ($dsn)
+    {
+        if (($pos = strpos($dsn, '?')) === false)
+        {
+            // /database
+            $parsed['database'] = rawurldecode($dsn);
+        }
+        else
+        {
+            // /database?param1=value1&param2=value2
+            $parsed['database'] = rawurldecode(substr($dsn, 0, $pos));
+            $dsn = substr($dsn, $pos + 1);
+            if (strpos($dsn, '&') !== false)
+            {
+                $opts = explode('&', $dsn);
+            }
+            else
+            { // database?param1=value1
+                $opts = array($dsn);
+            }
+            foreach ($opts as $opt)
+            {
+                list($key, $value) = explode('=', $opt);
+                if (!isset($parsed[$key]))
+                {
+                    // don't allow params overwrite
+                    $parsed[$key] = rawurldecode($value);
+                }
+            }
+        }
+    }
+
+    return $parsed;
+}
+
+function split_newlines($string)
+{
+    return preg_split('/\r\n|\n|\r/', $string);
+}
+
+function run_cmd($cmd)
+{
+    ob_start();
+    $ret = shell_exec($cmd);
+    ob_clean();
+    ob_end_clean();
+
+    return $ret;
+}

--- a/resources/drupal/settings.local.php
+++ b/resources/drupal/settings.local.php
@@ -4,6 +4,7 @@
 $databases['default']['default'] = array(
   'driver' => 'mysql',
   'host' => 'localhost',
+  'port'=>33306,
   'username' => '',
   'password' => '',
   'database' => '',

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,6 +13,7 @@ use CommerceGuys\Platform\Cli\Command\EnvironmentDeleteCommand;
 use CommerceGuys\Platform\Cli\Command\EnvironmentListCommand;
 use CommerceGuys\Platform\Cli\Command\EnvironmentMergeCommand;
 use CommerceGuys\Platform\Cli\Command\EnvironmentSynchronizeCommand;
+use CommerceGuys\Platform\Cli\Command\EnvironmentTunnelCommand;
 use CommerceGuys\Platform\Cli\Command\ProjectBuildCommand;
 use CommerceGuys\Platform\Cli\Command\ProjectDeleteCommand;
 use CommerceGuys\Platform\Cli\Command\ProjectGetCommand;
@@ -55,6 +56,7 @@ class Application extends BaseApplication {
         $this->add(new EnvironmentListCommand);
         $this->add(new EnvironmentMergeCommand);
         $this->add(new EnvironmentSynchronizeCommand);
+        $this->add(new EnvironmentTunnelCommand);
         $this->add(new ProjectBuildCommand);
         $this->add(new ProjectDeleteCommand);
         $this->add(new ProjectGetCommand);

--- a/src/Command/EnvironmentListCommand.php
+++ b/src/Command/EnvironmentListCommand.php
@@ -127,6 +127,7 @@ class EnvironmentListCommand extends EnvironmentCommand
         if ($this->operationAllowed('synchronize', $this->currentEnvironment)) {
             $output->writeln("Sync the current environment by running <info>platform environment:synchronize</info>.");
         }
+        $output->writeln("Create a tunnel to the current environment by running <info>platform environment:tunnel</info>.");
         $output->writeln("Execute drush commands against the current environment by running <info>platform drush</info>.");
         // Output a newline after the current block of commands.
         $output->writeln("");

--- a/src/Command/EnvironmentTunnelCommand.php
+++ b/src/Command/EnvironmentTunnelCommand.php
@@ -142,6 +142,9 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
     }
     }
     
+    /** FIXME: Opening tunnel first time will fail as ssh interactively asks to verify
+     *  server fingerprint
+     **/
     protected function open_tunnel(){
             $this->tunnels_config();
             $environmentId = $this->environment['id'];

--- a/src/Command/EnvironmentTunnelCommand.php
+++ b/src/Command/EnvironmentTunnelCommand.php
@@ -2,6 +2,7 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,6 +15,11 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
         $this
             ->setName('environment:tunnel')
             ->setDescription('Tunnel an environment.')
+             ->addArgument(
+                 'operation',
+                 InputArgument::OPTIONAL,
+                 '\'close\' will close an existing tunnel, \'status\' will output tunnel status'
+             )
             ->addOption(
                 'project',
                 null,
@@ -28,35 +34,123 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
             );
     }
 
+    protected function kill_existing($pid_file){
+          $output=[];
+          $outputs="";
+          if (file_exists($pid_file)){
+            $pids = file($pid_file, FILE_IGNORE_NEW_LINES);
+            if (!empty($pids)){
+              foreach ($pids as $pid){
+                exec("kill $pid", $output);
+                $outputs.=join("\n",$output);
+              }
+            exec(">| $pid_file");
+            }
+          }
+          return $outputs;
+    }
+
+    protected function show_status($pid_file){
+          $output=[];
+          $outputs="";
+          if (file_exists($pid_file)){
+            $pids = file($pid_file, FILE_IGNORE_NEW_LINES);
+            if (!empty($pids)){
+              $outputs="Found tunnel pids".join(", ",$pids)."\n";;
+              foreach ($pids as $pid){
+                exec("ps $pid", $output);
+                $outputs.=join("\n",$output);
+              }
+            }
+          }
+          return $outputs;
+    }
+    
+    protected function close_tunnel(){
+            $tmp_dir="/tmp";
+            $environmentId = $this->environment['id'];
+            $projectId = $this->project['id'];
+            $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
+            $tunnelPidFile ="$tmp_dir/platform-local-ssh-tunnel-$environmentId.pid";
+            $killOutPut = $this->kill_existing($webPidFile);
+            $killOutPut .= $this->kill_existing($tunnelPidFile);
+            $message = '<info>';
+            if(!empty($killOutPut)){$message .= "Killing Tunnel $killOutPut\n";}
+            $message .= "</info>";
+            return $message;
+    }
+
+    protected function status_tunnel(){
+            $tmp_dir="/tmp";
+            $environmentId = $this->environment['id'];
+            $projectId = $this->project['id'];
+            $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
+            $tunnelOutputFile ="$tmp_dir/platform-local-ssh-tunnel-$environmentId.log";
+            $tunnelPidFile ="$tmp_dir/platform-local-ssh-tunnel-$environmentId.pid";
+            
+            $statusOutPut = $this->show_status($webPidFile);
+            $statusOutPut .= $this->show_status($tunnelPidFile);
+            $message = '<info>';
+            $message = "Tunnel Status:\n";
+            if(!empty($statusOutPut)){$message .= " $statusOutPut\n";}
+            $message .= "</info>";
+            return $message;
+    }
+            
+    protected function open_tunnel(){
+            $environmentId = $this->environment['id'];
+            $projectId = $this->project['id'];
+            list($protocol,$sshUrl) = split('://',$this->environment["_links"]["ssh"]["href"]); // We can't pass the ssh:// protocol indentifier to the ssh command
+            $projectWWWRoot = $this->getProjectRoot()."/www";
+            $localhost = "local.platform.sh";
+            $mysql_local_port= 33306;
+            $http_local_port=  8000;
+            $tmp_dir="/tmp";
+            $tunnelCommand = "ssh -N -L$mysql_local_port:database.internal:3306 $sshUrl";
+            $serveCommand = "php -t $projectWWWRoot -S $localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"$projectWWWRoot/index.php\"); }'";
+            $webOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
+            $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
+            $tunnelOutputFile ="$tmp_dir/platform-local-ssh-tunnel-$environmentId.log";
+            $tunnelPidFile ="$tmp_dir/platform-local-ssh-tunnel-$environmentId.pid";
+
+            // we need to check the pid file here (and allow for a stop command...)
+
+            $command = sprintf("%s >> %s  2>&1 & echo $! >> %s", $serveCommand, $webOutputFile, $webPidFile);
+            exec($command);
+            $command = sprintf("%s >> %s 2>&1 & echo $! >> %s", $tunnelCommand, $tunnelOutputFile, $tunnelPidFile);
+            shell_exec($command);
+
+            $message = '<info>';
+            if(!empty($killOutPut)){$message .= "Killing existing tunnel $killOutPut\n";}
+            $message .= "\nA host has been configured as $localhost\n";
+            $message .= "\nA tunnel to environment $environmentId has been created. \n";
+            $message .= "\nSet your settings to connect $localhost:$mysql_local_port for mysql (do not use localhost !)\n";
+            $message .= "\nYou can see the site on http://$localhost:$http_local_port";
+            $message .= "</info>";
+            return $message;
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (!$this->validateInput($input, $output)) {
           return;
-        }        
-        $environmentId = $this->environment['id'];
-        $sshUrl= $this->environment["_links"]["ssh"]["href"];
-        $projectWWWRoot = $this->getProjectRoot()."/www";
-        $mysql_local_port= 3306;
-        $http_local_port=  8000;
-        $tmp_dir="/tmp";
+        }
         
-        $tunnelCommand = "ssh -L$mysql_local_port:database.internal:3306 $sshUrl\n";
-        $serveCommand = "php -t $projectWWWRoot -S localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"$projectWWWRoot/index.php\"); }'";
-
-        $webOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
-        $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
-        $tunnelOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
-        $tunnelPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
-
-        // we need to check the pid file here (and allow for a stop command...)
-        exec(sprintf("%s > %s 2>&1 & echo $! >> %s", $tunnelCommand, $tunnelOutputFile, $tunnelPidFile));
-        exec(sprintf("%s > %s 2>&1 & echo $! >> %s", $serveCommand, $webOutputFile, $webPidFile));
-
-        $message = '<info>';
-        $message .= "\nA tunnel to environment $environmentId has been created. \n";
-        $message .="\nSet your settings to connect to localhost:$mysql_local_port for mysql";
-        $message .="\nYou can see the site on http://locahost:$http_local_port";
-        $message .= "</info>";
+        $operation = $input->getArgument('operation');
+        
+        switch ($operation) {
+            case "close":
+                $message = $this->close_tunnel();
+                break;
+            case "status":
+                $message = $this->status_tunnel();
+                break;
+            case "open":
+            default:
+                $message = $this->open_tunnel();
+                break;
+        }
+        
         $output->writeln($message);
     }
 }

--- a/src/Command/EnvironmentTunnelCommand.php
+++ b/src/Command/EnvironmentTunnelCommand.php
@@ -96,18 +96,56 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
             $message .= "</info>";
             return $message;
     }
-            
+
+    protected function create_procfile(){
+
+    }
+
+    /*FIXME this is hardcoded for the moment as the API does not expose the relations*/
+    protected function tunnels_config(){
+      $this->tunnels=[];
+      $relations_json='{"solr": [{"host": "solr.internal", "scheme": "solr", "port": 8080}], "redis": [{"host": "redis.internal", "scheme": "redis", "port": 6379}], "database": [{"username": "", "password": "", "host": "database.internal", "query": {"is_master": true}, "path": "main", "scheme": "mysql", "port": 3306}]}';
+      $port_delta = 10000;             // FIXME bad idea
+      $this->relations=json_decode($relations_json);
+      foreach ($this->relations as $relation => $config) {
+        $this->tunnels[$relation]=
+          array(
+            "host"=>$config[0]->host,
+            "port"=>$config[0]->port,
+            "local_port"=> (int)$config[0]->port + $port_delta
+          );
+      }
+    }
+    
+    protected function tunnels_params(){
+      $params=[];
+      foreach ($this->tunnels as $tunnel=>$config){
+        $host = $config['host'];
+        $port = $config['port'];
+        $local_port=$config['local_port'];
+        $params[]= "-L $local_port:$host:$port";
+      }
+      return join(" ",$params);
+    }
+    protected function web_params($buildpack, $projectWWWRoot, $localhost, $http_local_port, $projectWWWRoot){
+      switch ($buildpack){
+        case "drupal":
+        default:
+        return "php -t $projectWWWRoot -S $localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"$projectWWWRoot/index.php\"); }'";
+    }
+    }
+    
     protected function open_tunnel(){
+            $this->tunnels_config();
             $environmentId = $this->environment['id'];
             $projectId = $this->project['id'];
-            list($protocol,$sshUrl) = split('://',$this->environment["_links"]["ssh"]["href"]); // We can't pass the ssh:// protocol indentifier to the ssh command
+            list($protocol,$sshUrl) = split('://', $this->environment["_links"]["ssh"]["href"]); // We can't pass the ssh:// protocol indentifier to the ssh command
             $projectWWWRoot = $this->getProjectRoot()."/www";
             $localhost = "local.platform.sh";
-            $mysql_local_port= 33306;
-            $http_local_port=  8000;
+            $http_local_port=  8000; //FIXME hardcoded
             $tmp_dir="/tmp";
-            $tunnelCommand = "ssh -N -L$mysql_local_port:database.internal:3306 $sshUrl";
-            $serveCommand = "php -t $projectWWWRoot -S $localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"$projectWWWRoot/index.php\"); }'";
+            $tunnelCommand = "ssh -N ". $this->tunnels_params() ." $sshUrl";
+            $serveCommand = $this->web_params();
             $webOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
             $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
             $tunnelOutputFile ="$tmp_dir/platform-local-ssh-tunnel-$environmentId.log";
@@ -123,7 +161,10 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
             $message = '<info>';
             if(!empty($killOutPut)){$message .= "Killing existing tunnel $killOutPut\n";}
             $message .= "\nA host has been configured as $localhost\n";
-            $message .= "\nA tunnel to environment $environmentId has been created. \n";
+            $message .= "\nA tunnel to environment $environmentId has been created ($tunnelCommand)\n";
+            foreach ($this->tunnels as $tunnel=>$config){
+              $message .= "Connect to $tunnel through $localhost:".$config["local_port"];
+            }
             $message .= "\nSet your settings to connect $localhost:$mysql_local_port for mysql (do not use localhost !)\n";
             $message .= "\nYou can see the site on http://$localhost:$http_local_port";
             $message .= "</info>";

--- a/src/Command/EnvironmentTunnelCommand.php
+++ b/src/Command/EnvironmentTunnelCommand.php
@@ -145,7 +145,7 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
             $http_local_port=  8000; //FIXME hardcoded
             $tmp_dir="/tmp";
             $tunnelCommand = "ssh -N ". $this->tunnels_params() ." $sshUrl";
-            $serveCommand = $this->web_params();
+            $serveCommand = $this->web_params($buildpack, $projectWWWRoot, $localhost, $http_local_port, $projectWWWRoot);
             $webOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
             $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
             $tunnelOutputFile ="$tmp_dir/platform-local-ssh-tunnel-$environmentId.log";
@@ -166,7 +166,7 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
               $message .= "Connect to $tunnel through $localhost:".$config["local_port"];
             }
             $message .= "\nSet your settings to connect $localhost:$mysql_local_port for mysql (do not use localhost !)\n";
-            $message .= "\nYou can see the site on http://$localhost:$http_local_port";
+            $message .= "\nYou can see the site on http://$localhost:$http_local_port\n$serveCommand\n";
             $message .= "</info>";
             return $message;
     }

--- a/src/Command/EnvironmentTunnelCommand.php
+++ b/src/Command/EnvironmentTunnelCommand.php
@@ -35,13 +35,13 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
         }        
         $environmentId = $this->environment['id'];
         $sshUrl= $this->environment["_links"]["ssh"]["href"];
-        $projectRoot = $this->getProjectRoot();
+        $projectWWWRoot = $this->getProjectRoot()."/www";
         $mysql_local_port= 3306;
         $http_local_port=  8000;
         $tmp_dir="/tmp";
         
         $tunnelCommand = "ssh -L$mysql_local_port:database.internal:3306 $sshUrl\n";
-        $serveCommand = "php -t $projectRoot/www -S localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"index.php\"); }'";
+        $serveCommand = "php -t $projectWWWRoot -S localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"$projectWWWRoot/index.php\"); }'";
 
         $webOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
         $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";

--- a/src/Command/EnvironmentTunnelCommand.php
+++ b/src/Command/EnvironmentTunnelCommand.php
@@ -128,13 +128,14 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
       return join(" ",$params);
     }
     protected function web_params($buildpack, $projectWWWRoot, $localhost, $http_local_port, $projectWWWRoot){
+        /*FIXME All of this should go to the buildpack/plugin model*/
       switch ($buildpack){
         case "symfony":
         /*FIXME 
         we should get this from composer.json
         extra:symfony-web-dir
         */
-        return "php -t $projectWWWRoot/web/app.php/ -S $localhost:$http_local_port }'";
+        return "php -t $projectWWWRoot/web/app.php/ -S $localhost:$http_local_port";
         case "drupal":
         default:
         return "php -t $projectWWWRoot -S $localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"$projectWWWRoot/index.php\"); }'";
@@ -151,6 +152,8 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
             $http_local_port=  8000; //FIXME hardcoded
             $tmp_dir="/tmp";
             $tunnelCommand = "ssh -N ". $this->tunnels_params() ." $sshUrl";
+            /*FIXME THIS IS Unfinished.. we need to get this from the detect we have on build*/
+            $buildpack ="symfony";
             $serveCommand = $this->web_params($buildpack, $projectWWWRoot, $localhost, $http_local_port, $projectWWWRoot);
             $webOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
             $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";

--- a/src/Command/EnvironmentTunnelCommand.php
+++ b/src/Command/EnvironmentTunnelCommand.php
@@ -129,6 +129,12 @@ class EnvironmentTunnelCommand extends EnvironmentCommand
     }
     protected function web_params($buildpack, $projectWWWRoot, $localhost, $http_local_port, $projectWWWRoot){
       switch ($buildpack){
+        case "symfony":
+        /*FIXME 
+        we should get this from composer.json
+        extra:symfony-web-dir
+        */
+        return "php -t $projectWWWRoot/web/app.php/ -S $localhost:$http_local_port }'";
         case "drupal":
         default:
         return "php -t $projectWWWRoot -S $localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"$projectWWWRoot/index.php\"); }'";

--- a/src/Command/EnvironmentTunnelCommand.php
+++ b/src/Command/EnvironmentTunnelCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace CommerceGuys\Platform\Cli\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnvironmentTunnelCommand extends EnvironmentCommand
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('environment:tunnel')
+            ->setDescription('Tunnel an environment.')
+            ->addOption(
+                'project',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The project id'
+            )
+            ->addOption(
+                'environment',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The environment id'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (!$this->validateInput($input, $output)) {
+          return;
+        }        
+        $environmentId = $this->environment['id'];
+        $sshUrl= $this->environment["_links"]["ssh"]["href"];
+        $projectRoot = $this->getProjectRoot();
+        $mysql_local_port= 3306;
+        $http_local_port=  8000;
+        $tmp_dir="/tmp";
+        
+        $tunnelCommand = "ssh -L$mysql_local_port:database.internal:3306 $sshUrl\n";
+        $serveCommand = "php -t $projectRoot/www -S localhost:$http_local_port -r'if (preg_match(\"/\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)/\",\$_SERVER[\"REQUEST_URI\"])) { print \"Error\\n\"; } else if (preg_match(\"/(^|\/)\./\",\$_SERVER[\"REQUEST_URI\"])) { return false; } else if (file_exists(\$_SERVER[\"DOCUMENT_ROOT\"].\$_SERVER[\"SCRIPT_NAME\"])) { return false; } else {\$_GET[\"q\"]=\$_SERVER[\"REQUEST_URI\"]; include(\"index.php\"); }'";
+
+        $webOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
+        $webPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
+        $tunnelOutputFile ="$tmp_dir/platform-local-web-server-$environmentId.log";
+        $tunnelPidFile ="$tmp_dir/platform-local-web-server-$environmentId.pid";
+
+        // we need to check the pid file here (and allow for a stop command...)
+        exec(sprintf("%s > %s 2>&1 & echo $! >> %s", $tunnelCommand, $tunnelOutputFile, $tunnelPidFile));
+        exec(sprintf("%s > %s 2>&1 & echo $! >> %s", $serveCommand, $webOutputFile, $webPidFile));
+
+        $message = '<info>';
+        $message .= "\nA tunnel to environment $environmentId has been created. \n";
+        $message .="\nSet your settings to connect to localhost:$mysql_local_port for mysql";
+        $message .="\nYou can see the site on http://locahost:$http_local_port";
+        $message .= "</info>";
+        $output->writeln($message);
+    }
+}
+


### PR DESCRIPTION
Hacky and unfinished.

BAsically what it does is open tunnel(s) for the relations (currently hardcoded).
I put local.platform.sh 127.0.0.1 in my /etc/hosts file but it would be much cooler to resolve local.platform.sh to 127.0.0.1 through dns...
There is some stuff to be done around configuration still for Drupal and probably Symfony (solr config in db?).

```text
A host has been configured as local.platform.sh

A tunnel to environment mybranch has been created (ssh -N -L 18080:solr.internal:8080 -L 16379:redis.internal:6379 -L 13306:database.internal:3306 pxbzj2d3rq6rc-mybranch@ssh.eu.platform.sh)
Connect to solr through local.platform.sh:18080Connect to redis through local.platform.sh:16379Connect to database through local.platform.sh:13306
Set your settings to connect local.platform.sh: for mysql (do not use localhost !)

You can see the site on http://local.platform.sh:8000
```