### PR TITLE
Archive and re-use old builds if the app's files have not changed

### DIFF
--- a/src/Command/ProjectGetCommand.php
+++ b/src/Command/ProjectGetCommand.php
@@ -2,6 +2,7 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use CommerceGuys\Platform\Cli\Local\LocalBuild;
 use CommerceGuys\Platform\Cli\Local\LocalProject;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -165,13 +166,9 @@ class ProjectGetCommand extends PlatformCommand
         }
 
         // Launch the first build.
-        /** @var ProjectBuildCommand $buildCommand */
-        $buildCommand = $this->getApplication()->find('build');
-        $buildSettings = array(
-            'environmentId' => $environment,
-        );
         try {
-            $buildCommand->build($projectRoot, $buildSettings, $output);
+            $builder = new LocalBuild(array('environmentId' => $environment));
+            $builder->buildProject($projectRoot, $output);
         }
         catch (\Exception $e) {
             $output->writeln("<comment>The build failed with an error</comment>");

--- a/src/Command/UrlCommandBase.php
+++ b/src/Command/UrlCommandBase.php
@@ -41,6 +41,8 @@ abstract class UrlCommandBase extends PlatformCommand
             return;
         }
 
+        $shellHelper = $this->getHelper('shell');
+
         if ($browser === '0') {
             // The user has requested not to use a browser.
             $browser = false;
@@ -49,14 +51,14 @@ abstract class UrlCommandBase extends PlatformCommand
             // Find a default browser to use.
             $browser = $this->getDefaultBrowser();
         }
-        elseif (!$this->browserExists($browser)) {
+        elseif (!$shellHelper->commandExists($browser)) {
             // The user has specified a browser, but it can't be found.
             $output->writeln("<error>Browser not found: $browser</error>");
             $browser = false;
         }
 
         if ($browser) {
-            $opened = $this->getHelper('shell')->execute(array($browser, $url));
+            $opened = $shellHelper->execute(array($browser, $url));
             if ($opened) {
                 $output->writeln("Opened: $url");
                 return;
@@ -64,22 +66,6 @@ abstract class UrlCommandBase extends PlatformCommand
         }
 
         $output->writeln($url);
-    }
-
-
-    /**
-     * @param string $browser
-     * @return bool
-     */
-    protected function browserExists($browser)
-    {
-        if (strpos(PHP_OS, 'WIN') !== false) {
-            $args = array('where', $browser);
-        }
-        else {
-            $args = array('command', '-v', $browser);
-        }
-        return (bool) $this->getHelper('shell')->execute($args);
     }
 
     /**
@@ -92,7 +78,7 @@ abstract class UrlCommandBase extends PlatformCommand
         $potential = array('xdg-open', 'open', 'start');
         $shellHelper = $this->getHelper('shell');
         foreach ($potential as $browser) {
-            if ($shellHelper->execute(array('which', $browser))) {
+            if ($shellHelper->commandExists($browser)) {
                 return $browser;
             }
         }

--- a/src/Helper/ShellHelper.php
+++ b/src/Helper/ShellHelper.php
@@ -83,4 +83,17 @@ class ShellHelper extends Helper implements ShellHelperInterface {
 
         return $output ? rtrim($output) : true;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function commandExists($command)
+    {
+        $args = array('command', '-v', $command);
+        if (strpos(PHP_OS, 'WIN') !== false) {
+            $args = array('where', $command);
+        }
+        return (bool) $this->execute($args);
+    }
+
 }

--- a/src/Helper/ShellHelperInterface.php
+++ b/src/Helper/ShellHelperInterface.php
@@ -32,4 +32,13 @@ interface ShellHelperInterface {
      */
     public function setOutput(OutputInterface $output);
 
+    /**
+     * Check whether a shell command exists.
+     *
+     * @param string $command
+     *
+     * @return bool
+     */
+    public function commandExists($command);
+
 }

--- a/src/Local/LocalBuild.php
+++ b/src/Local/LocalBuild.php
@@ -349,7 +349,7 @@ class LocalBuild
                 continue;
             }
             $filename = $directory . '/' . $entry;
-            if ($ttl && $now - filemtime($filename) > $ttl || $keepMax && $numKept >= $keepMax) {
+            if (($ttl && $now - filemtime($filename) > $ttl) || $numKept >= $keepMax) {
                 $output->writeln("Deleting: $entry");
                 $this->fsHelper->remove($filename);
                 $numDeleted++;

--- a/src/Local/LocalBuild.php
+++ b/src/Local/LocalBuild.php
@@ -2,19 +2,45 @@
 namespace CommerceGuys\Platform\Cli\Local;
 
 use CommerceGuys\Platform\Cli\Local\Toolstack\ToolstackInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Parser;
 
 class LocalBuild {
 
+    protected $settings;
+
     /**
      * @return ToolstackInterface[]
      */
-    public static function getToolstacks()
+    public function getToolstacks()
     {
         return array(
             new Toolstack\Drupal(),
             new Toolstack\Symfony(),
         );
+    }
+
+    /**
+     * @param array $settings
+     */
+    public function __construct(array $settings = array())
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * @param string $projectRoot
+     * @param OutputInterface $output
+     * @return bool
+     */
+    public function buildProject($projectRoot, OutputInterface $output)
+    {
+        $repositoryRoot = $this->getRepositoryRoot($projectRoot);
+        $success = true;
+        foreach ($this->getApplications($repositoryRoot) as $appRoot) {
+            $success = $this->buildApp($appRoot, $projectRoot, $output) && $success;
+        }
+        return $success;
     }
 
     /**
@@ -24,7 +50,7 @@ class LocalBuild {
      *
      * @return string[]    A list of directories containing applications.
      */
-    public static function getApplications($repositoryRoot)
+    public function getApplications($repositoryRoot)
     {
         // @todo: Determine multiple project roots, perhaps using Finder again
         return array($repositoryRoot);
@@ -37,7 +63,7 @@ class LocalBuild {
      *
      * @return array
      */
-    public static function getAppConfig($appRoot)
+    public function getAppConfig($appRoot)
     {
         if (file_exists($appRoot . '/.platform.app.yaml')) {
             $parser = new Parser();
@@ -56,7 +82,7 @@ class LocalBuild {
      *
      * @return ToolstackInterface|false
      */
-    public static function getToolstack($appRoot, array $appConfig = array())
+    public function getToolstack($appRoot, array $appConfig = array())
     {
         $toolstackChoice = false;
         if (isset($appConfig['toolstack'])) {
@@ -71,7 +97,94 @@ class LocalBuild {
         if ($toolstackChoice) {
             throw new \Exception("Toolstack not found: $toolstackChoice");
         }
+
         return false;
+    }
+
+    /**
+     * @var string $projectRoot
+     * @return string
+     */
+    protected function getRepositoryRoot($projectRoot)
+    {
+        return $projectRoot . '/repository';
+    }
+
+    /**
+     * @param string $appRoot
+     * @param string $projectRoot
+     * @param OutputInterface $output
+     *
+     * @return bool
+     */
+    protected function buildApp($appRoot, $projectRoot, OutputInterface $output)
+    {
+        $repositoryRoot = $this->getRepositoryRoot($projectRoot);
+
+        $appConfig = $this->getAppConfig($appRoot);
+        $appName = false;
+        if (isset($appConfig['name'])) {
+            $appName = $appConfig['name'];
+        }
+        elseif ($appRoot != $repositoryRoot) {
+            $appName = str_replace($repositoryRoot, '', $appRoot);
+        }
+
+        $toolstack = $this->getToolstack($appRoot, $appConfig);
+        if (!$toolstack) {
+            $output->writeln("<comment>Could not detect toolstack for directory: $appRoot</comment>");
+            return false;
+        }
+
+        $message = "Building application";
+        if ($appName) {
+            $message .= " <info>$appName</info>";
+        }
+        $message .= " using the toolstack <info>" . $toolstack->getKey() . "</info>";
+        $output->writeln($message);
+
+        $toolstack->setOutput($output);
+        $toolstack->prepareBuild($appRoot, $projectRoot, $this->settings);
+
+        $toolstack->build();
+        $toolstack->install();
+
+        $this->warnAboutHooks($appConfig, $output);
+
+        $message = "Build complete";
+        if ($appName) {
+            $message .= " for <info>$appName</info>";
+        }
+        $output->writeln($message);
+        return true;
+    }
+
+    /**
+     * Warn the user that the CLI will not run build/deploy hooks.
+     *
+     * @param array $appConfig
+     * @param OutputInterface $output
+     *
+     * @return bool
+     */
+    protected function warnAboutHooks(array $appConfig, OutputInterface $output)
+    {
+        if (empty($appConfig['hooks'])) {
+            return false;
+        }
+        $indent = '        ';
+        $output->writeln("<comment>You have defined the following hook(s). The CLI cannot run them locally.</comment>");
+        foreach (array('build', 'deploy') as $hookType) {
+            if (empty($appConfig['hooks'][$hookType])) {
+                continue;
+            }
+            $output->writeln("    $hookType: |");
+            $hooks = (array) $appConfig['hooks'][$hookType];
+            $asString = implode("\n", array_map('trim', $hooks));
+            $withIndent = $indent . str_replace("\n", "\n$indent", $asString);
+            $output->writeln($withIndent);
+        }
+        return true;
     }
 
 }

--- a/src/Local/LocalBuild.php
+++ b/src/Local/LocalBuild.php
@@ -1,13 +1,19 @@
 <?php
 namespace CommerceGuys\Platform\Cli\Local;
 
+use CommerceGuys\Platform\Cli\Helper\FilesystemHelper;
+use CommerceGuys\Platform\Cli\Helper\GitHelper;
 use CommerceGuys\Platform\Cli\Local\Toolstack\ToolstackInterface;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Parser;
 
-class LocalBuild {
+class LocalBuild
+{
 
     protected $settings;
+    protected $fsHelper;
+    protected $gitHelper;
 
     /**
      * @return ToolstackInterface[]
@@ -15,22 +21,27 @@ class LocalBuild {
     public function getToolstacks()
     {
         return array(
-            new Toolstack\Drupal(),
-            new Toolstack\Symfony(),
+          new Toolstack\Drupal(),
+          new Toolstack\Symfony(),
         );
     }
 
     /**
-     * @param array $settings
+     * @param array  $settings
+     * @param object $fsHelper
+     * @param object $gitHelper
      */
-    public function __construct(array $settings = array())
+    public function __construct(array $settings = array(), $fsHelper = null, $gitHelper = null)
     {
         $this->settings = $settings;
+        $this->fsHelper = $fsHelper ?: new FilesystemHelper();
+        $this->gitHelper = $gitHelper ?: new GitHelper();
     }
 
     /**
-     * @param string $projectRoot
+     * @param string          $projectRoot
      * @param OutputInterface $output
+     *
      * @return bool
      */
     public function buildProject($projectRoot, OutputInterface $output)
@@ -40,13 +51,19 @@ class LocalBuild {
         foreach ($this->getApplications($repositoryRoot) as $appRoot) {
             $success = $this->buildApp($appRoot, $projectRoot, $output) && $success;
         }
+        if (empty($this->settings['noClean'])) {
+            $output->writeln("Cleaning up...");
+            $this->cleanBuilds($projectRoot);
+            $this->cleanArchives($projectRoot);
+        }
+
         return $success;
     }
 
     /**
      * Get a list of applications in the repository.
      *
-     * @param string $repositoryRoot   The absolute path to the repository.
+     * @param string $repositoryRoot The absolute path to the repository.
      *
      * @return string[]    A list of directories containing applications.
      */
@@ -59,24 +76,32 @@ class LocalBuild {
     /**
      * Get the application's configuration, parsed from its YAML definition.
      *
-     * @param string $appRoot   The absolute path to the application.
+     * @param string $appRoot The absolute path to the application.
      *
      * @return array
      */
     public function getAppConfig($appRoot)
     {
+        $config = array();
         if (file_exists($appRoot . '/.platform.app.yaml')) {
             $parser = new Parser();
-            return (array) $parser->parse(file_get_contents($appRoot . '/.platform.app.yaml'));
+            $config = (array) $parser->parse(file_get_contents($appRoot . '/.platform.app.yaml'));
         }
-        return array();
+        if (!isset($config['name'])) {
+            $dir = basename(dirname($appRoot));
+            if ($dir != 'repository') {
+                $config['name'] = $dir;
+            }
+        }
+
+        return $config;
     }
 
     /**
      * Get the toolstack for a particular application.
      *
      * @param string $appRoot   The absolute path to the application.
-     * @param mixed $appConfig  The application's configuration.
+     * @param mixed  $appConfig The application's configuration.
      *
      * @throws \Exception   If a specified toolstack is not found.
      *
@@ -112,41 +137,112 @@ class LocalBuild {
 
     /**
      * @param string $appRoot
-     * @param string $projectRoot
+     *
+     * @return string|false
+     */
+    protected function getTreeId($appRoot)
+    {
+        $hashes = array();
+
+        // Get a hash representing all the files in the application, excluding
+        // the .platform folder.
+        $tree = $this->gitHelper->execute(array('ls-tree', 'HEAD'), $appRoot, true);
+        if ($tree === false) {
+            return false;
+        }
+        $tree = preg_replace('#^|\n[^\n]+?\.platform\n|$#', "\n", $tree);
+        $hashes[] = sha1($tree);
+
+        // Include the hashes of untracked and modified files.
+        $others = $this->gitHelper->execute(
+          array('ls-files', '--modified', '--others', '--exclude-standard', '-x .platform', '.'),
+          $appRoot
+        );
+        if ($others === false) {
+            return false;
+        }
+        $count = 0;
+        foreach (explode("\n", $others) as $filename) {
+            if ($count > 5000) {
+                return false;
+            }
+            $filename = "$appRoot/$filename";
+            if (is_file($filename)) {
+                $hashes[] = sha1_file($filename);
+                $count++;
+            }
+        }
+
+        // Combine them all.
+        return sha1(implode(' ', $hashes));
+    }
+
+    /**
+     * @param string          $appRoot
+     * @param string          $projectRoot
      * @param OutputInterface $output
      *
      * @return bool
      */
     protected function buildApp($appRoot, $projectRoot, OutputInterface $output)
     {
-        $repositoryRoot = $this->getRepositoryRoot($projectRoot);
-
         $appConfig = $this->getAppConfig($appRoot);
-        $appName = false;
-        if (isset($appConfig['name'])) {
-            $appName = $appConfig['name'];
-        }
-        elseif ($appRoot != $repositoryRoot) {
-            $appName = str_replace($repositoryRoot, '', $appRoot);
-        }
+        $verbose = $output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE;
+
+        $appName = isset($appConfig['name']) ? $appConfig['name'] : false;
+
+        $buildName = date('Y-m-d--H-i-s') . '--' . $this->settings['environmentId'];
+        $buildDir = $projectRoot . '/builds/' . $buildName;
 
         $toolstack = $this->getToolstack($appRoot, $appConfig);
         if (!$toolstack) {
             $output->writeln("<comment>Could not detect toolstack for directory: $appRoot</comment>");
+
             return false;
         }
 
-        $message = "Building application";
-        if ($appName) {
-            $message .= " <info>$appName</info>";
+        $toolstack->prepare($buildDir, $appRoot, $projectRoot, $this->settings);
+
+        $archive = false;
+        if (empty($this->settings['noArchive'])) {
+            $treeId = $this->getTreeId($appRoot);
+            if ($treeId) {
+                if ($verbose) {
+                    $output->writeln("Tree ID: $treeId");
+                }
+                $archive = $projectRoot . '/.build-archives/' . $treeId . '.tar.gz';
+            }
         }
-        $message .= " using the toolstack <info>" . $toolstack->getKey() . "</info>";
-        $output->writeln($message);
 
-        $toolstack->setOutput($output);
-        $toolstack->prepareBuild($appRoot, $projectRoot, $this->settings);
+        if ($archive && file_exists($archive)) {
+            $message = "Extracting archive";
+            if ($appName) {
+                $message .= " for application <info>$appName</info>";
+            }
+            $message .= '...';
+            $output->writeln($message);
+            $this->fsHelper->extractArchive($archive, $buildDir);
+        } else {
+            $message = "Building application";
+            if ($appName) {
+                $message .= " <info>$appName</info>";
+            }
+            $message .= " using the toolstack <info>" . $toolstack->getKey() . "</info>";
+            $output->writeln($message);
 
-        $toolstack->build();
+            $toolstack->setOutput($output);
+
+            $toolstack->build();
+
+            if ($archive) {
+                $output->writeln("Saving build archive...");
+                if (!is_dir(dirname($archive))) {
+                    mkdir(dirname($archive));
+                }
+                $this->fsHelper->archiveDir($buildDir, $archive);
+            }
+        }
+
         $toolstack->install();
 
         $this->warnAboutHooks($appConfig, $output);
@@ -156,20 +252,21 @@ class LocalBuild {
             $message .= " for <info>$appName</info>";
         }
         $output->writeln($message);
+
         return true;
     }
 
     /**
      * Warn the user that the CLI will not run build/deploy hooks.
      *
-     * @param array $appConfig
+     * @param array           $appConfig
      * @param OutputInterface $output
      *
      * @return bool
      */
     protected function warnAboutHooks(array $appConfig, OutputInterface $output)
     {
-        if (empty($appConfig['hooks'])) {
+        if (empty($appConfig['hooks']['build'])) {
             return false;
         }
         $indent = '        ';
@@ -184,7 +281,85 @@ class LocalBuild {
             $withIndent = $indent . str_replace("\n", "\n$indent", $asString);
             $output->writeln($withIndent);
         }
+
         return true;
+    }
+
+    /**
+     * Remove old builds.
+     *
+     * This preserves the currently active build.
+     *
+     * @param string          $projectRoot
+     * @param int             $ttl
+     * @param int             $keepMax
+     * @param OutputInterface $output
+     *
+     * @return int[]
+     *   The numbers of kept and deleted builds.
+     */
+    public function cleanBuilds($projectRoot, $ttl = 86400, $keepMax = 10, OutputInterface $output = null)
+    {
+        $blacklist = array();
+        if (is_link($projectRoot . '/www') && ($target = readlink($projectRoot . '/www'))) {
+            $blacklist[] = basename($target);
+        }
+
+        return $this->cleanDirectory($projectRoot . '/builds', $ttl, $keepMax, $blacklist, $output);
+    }
+
+    /**
+     * Remove old build archives.
+     *
+     * @param string $projectRoot
+     * @param int    $ttl
+     * @param int    $keepMax
+     *
+     * @return int[]
+     *   The numbers of kept and deleted builds.
+     */
+    public function cleanArchives($projectRoot, $ttl = 604800, $keepMax = 10)
+    {
+        return $this->cleanDirectory($projectRoot . '/.build-archives', $ttl, $keepMax);
+    }
+
+    /**
+     * Remove old files from a directory.
+     *
+     * @param string          $directory
+     * @param int             $ttl
+     * @param int             $keepMax
+     * @param array           $blacklist
+     * @param OutputInterface $output
+     *
+     * @return array
+     */
+    protected function cleanDirectory($directory, $ttl, $keepMax = 0, array $blacklist = array(), OutputInterface $output = null)
+    {
+        if (!is_dir($directory)) {
+            return array(0, 0);
+        }
+        $output = $output ?: new NullOutput();
+        $handle = opendir($directory);
+        $now = time();
+        $numDeleted = 0;
+        $numKept = 0;
+        while ($entry = readdir($handle)) {
+            if ($entry[0] == '.' || in_array($entry, $blacklist)) {
+                continue;
+            }
+            $filename = $directory . '/' . $entry;
+            if ($ttl && $now - filemtime($filename) > $ttl || $keepMax && $numKept >= $keepMax) {
+                $output->writeln("Deleting: $entry");
+                $this->fsHelper->remove($filename);
+                $numDeleted++;
+            } else {
+                $numKept++;
+            }
+        }
+        closedir($handle);
+
+        return array($numDeleted, $numKept);
     }
 
 }

--- a/src/Local/Toolstack/Drupal.php
+++ b/src/Local/Toolstack/Drupal.php
@@ -74,6 +74,7 @@ class Drupal extends ToolstackBase
             $this->buildMode = 'vanilla';
             $this->buildDir = $this->appRoot;
         }
+        $this->symLinkSpecialDestinations();
     }
 
     /**
@@ -244,8 +245,6 @@ class Drupal extends ToolstackBase
         // @todo: Figure out a way to split up local shared resources by application.
 
         $this->fsHelper->symlinkAll($this->projectRoot . '/shared', $buildDir . '/sites/default');
-
-        $this->symLinkSpecialDestinations();
 
         // Point www to the latest build.
         $this->fsHelper->symLink($buildDir, $this->projectRoot . '/www');

--- a/src/Local/Toolstack/Symfony.php
+++ b/src/Local/Toolstack/Symfony.php
@@ -39,9 +39,12 @@ class Symfony extends ToolstackBase
         else {
             throw new \Exception("Couldn't create build directory");
         }
+
+        $this->symLinkSpecialDestinations();
     }
 
-    public function install() {
+    public function install()
+    {
         $buildDir = $this->buildDir;
 
         // The build has been done, create a config_dev.yml if it is missing.

--- a/src/Local/Toolstack/ToolstackBase.php
+++ b/src/Local/Toolstack/ToolstackBase.php
@@ -63,14 +63,13 @@ abstract class ToolstackBase implements ToolstackInterface
         $this->shellHelper->setOutput($output);
     }
 
-    public function prepareBuild($appRoot, $projectRoot, array $settings)
+    public function prepare($buildDir, $appRoot, $projectRoot, array $settings)
     {
         $this->appRoot = $appRoot;
         $this->projectRoot = $projectRoot;
         $this->settings = $settings;
 
-        $buildName = date('Y-m-d--H-i-s') . '--' . $settings['environmentId'];
-        $this->buildDir = $projectRoot . '/builds/' . $buildName;
+        $this->buildDir = $buildDir;
 
         $this->absoluteLinks = !empty($settings['absoluteLinks']);
         $this->fsHelper->setRelativeLinks(!$this->absoluteLinks);

--- a/src/Local/Toolstack/ToolstackInterface.php
+++ b/src/Local/Toolstack/ToolstackInterface.php
@@ -35,11 +35,12 @@ interface ToolstackInterface
      *
      * This function should be isometric and not affect the file system.
      *
+     * @param string $buildDir
      * @param string $appRoot
      * @param string $projectRoot
      * @param array $settings
      */
-    public function prepareBuild($appRoot, $projectRoot, array $settings);
+    public function prepare($buildDir, $appRoot, $projectRoot, array $settings);
 
     /**
      * Build this application. Acquire dependencies, plugins, libraries, and

--- a/src/Local/Toolstack/ToolstackInterface.php
+++ b/src/Local/Toolstack/ToolstackInterface.php
@@ -49,8 +49,8 @@ interface ToolstackInterface
     public function build();
 
     /**
-     * Move files into place and symlink appropriate locations
-     * from the local shared/ folder into the application's web root.
+     * Move files into place. This could happen straight after the build, or
+     * after an old build archive has been extracted.
      */
     public function install();
 

--- a/tests/Local/LocalBuildTest.php
+++ b/tests/Local/LocalBuildTest.php
@@ -53,7 +53,7 @@ class LocalBuildTest extends \PHPUnit_Framework_TestCase
 
         $builder = new LocalBuild();
         $config = $builder->getAppConfig($fakeAppRoot);
-        $this->assertEquals(array(), $config);
+        $this->assertEquals(array('name' => 'data'), $config);
     }
 
 }

--- a/tests/Local/LocalBuildTest.php
+++ b/tests/Local/LocalBuildTest.php
@@ -15,10 +15,12 @@ class LocalBuildTest extends \PHPUnit_Framework_TestCase
         $appRoot = 'tests/data/apps/drupal';
         $appConfig = array('toolstack' => 'php:drupal');
 
-        $toolstackWithConfig = LocalBuild::getToolstack($appRoot, $appConfig);
+        $builder = new LocalBuild();
+
+        $toolstackWithConfig = $builder->getToolstack($appRoot, $appConfig);
         $this->assertInstanceOf($toolstackClassName, $toolstackWithConfig, 'Detect Drupal app from config');
 
-        $toolstackNoConfig = LocalBuild::getToolstack($appRoot);
+        $toolstackNoConfig = $builder->getToolstack($appRoot);
         $this->assertInstanceOf($toolstackClassName, $toolstackNoConfig, 'Detect Drupal app from makefile-based file structure');
     }
 
@@ -28,10 +30,12 @@ class LocalBuildTest extends \PHPUnit_Framework_TestCase
         $appRoot = 'tests/data/apps/symfony';
         $appConfig = array('toolstack' => 'php:symfony');
 
-        $toolstackWithConfig = LocalBuild::getToolstack($appRoot, $appConfig);
+        $builder = new LocalBuild();
+
+        $toolstackWithConfig = $builder->getToolstack($appRoot, $appConfig);
         $this->assertInstanceOf($toolstackClassName, $toolstackWithConfig, 'Detect Symfony app from config');
 
-        $toolstackNoConfig = LocalBuild::getToolstack($appRoot);
+        $toolstackNoConfig = $builder->getToolstack($appRoot);
         $this->assertInstanceOf($toolstackClassName, $toolstackNoConfig, 'Detect Symfony app from file structure');
     }
 
@@ -39,14 +43,16 @@ class LocalBuildTest extends \PHPUnit_Framework_TestCase
     {
         $fakeAppRoot = 'tests/data/apps';
 
-        $this->assertFalse(LocalBuild::getToolstack($fakeAppRoot));
+        $builder = new LocalBuild();
+        $this->assertFalse($builder->getToolstack($fakeAppRoot));
     }
 
     public function testGetAppConfig()
     {
         $fakeAppRoot = 'tests/data/apps';
 
-        $config = LocalBuild::getAppConfig($fakeAppRoot);
+        $builder = new LocalBuild();
+        $config = $builder->getAppConfig($fakeAppRoot);
         $this->assertEquals(array(), $config);
     }
 


### PR DESCRIPTION
Addresses my #179.

 - [x] is there a way we can make the tree id match Platform's? [not really, no]
 - the tar/untar commands need cross-platform testing:
   - [x] OS X (Yosemite)
   - [x] Ubuntu (Trusty)
   - [x] Fedora (20)
   - [x] Other Unix (FreeBSD 10)
   - [ ] Windows 7
   - [ ] Windows 8
 - [x] there is no point keeping old build directories with this (not sure there was any point in the first place)
 - [x] refactor and modify the 'clean' command so that it deletes the 'slugs'
 - [ ] write automated tests