### PR TITLE
Add an environment argument to many commands

### DIFF
--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -57,7 +57,18 @@ class CompletionCommand extends ParentCompletionCommand
             ),
             Completion::makeGlobalHandler(
               'environment',
+              Completion::TYPE_ARGUMENT,
+              array($this, 'getEnvironments')
+            ),
+            Completion::makeGlobalHandler(
+              'environment',
               Completion::TYPE_OPTION,
+              array($this, 'getEnvironments')
+            ),
+            new Completion(
+              'environment:branch',
+              'parent',
+              Completion::TYPE_ARGUMENT,
               array($this, 'getEnvironments')
             ),
             new Completion(

--- a/src/Command/EnvironmentActivateCommand.php
+++ b/src/Command/EnvironmentActivateCommand.php
@@ -14,7 +14,7 @@ class EnvironmentActivateCommand extends EnvironmentCommand
         $this
             ->setName('environment:activate')
             ->setDescription('Activate an environment')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment to activate');
+            ->addArgument('environment', InputArgument::IS_ARRAY, 'The environment(s) to activate');
         $this->addProjectOption()->addEnvironmentOption();
     }
 
@@ -24,23 +24,64 @@ class EnvironmentActivateCommand extends EnvironmentCommand
             return 1;
         }
 
-        $environmentId = $this->environment['id'];
+        $environments = $this->environment ? array($this->environment) : $input->getArgument('environment');
 
-        if (!$this->operationAllowed('activate')) {
-            if (!empty($this->environment['_links']['public-url'])) {
-                $output->writeln("The environment <info>$environmentId</info> is already active.");
-                return 0;
-            }
-            $output->writeln(
-              "Operation not permitted: The environment <error>$environmentId</error> can't be activated."
-            );
-            return 1;
-        }
+        $success = $this->activateMultiple($environments, $input, $output);
 
-        $client = $this->getPlatformClient($this->environment['endpoint']);
-        $client->activateEnvironment();
-
-        $output->writeln("The environment <info>$environmentId</info> has been activated.");
-        return 0;
+        return $success ? 0 : 1;
     }
+
+    /**
+     * @param array           $environments
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return bool
+     */
+    protected function activateMultiple(array $environments, InputInterface $input, OutputInterface $output)
+    {
+        $count = count($environments);
+        $processed = 0;
+        // Confirm which environments the user wishes to be deactivated.
+        $process = array();
+        $questionHelper = $this->getHelper('question');
+        foreach ($environments as $environment) {
+            if (!is_array($environment)) {
+                $requested = $environment;
+                $environment = $this->getEnvironment($environment, $this->project);
+                if (!$environment) {
+                    $output->writeln("Environment not found: <error>$requested</error>");
+                    continue;
+                }
+            }
+            $environmentId = $environment['id'];
+            if (!empty($environment['_links']['public-url'])) {
+                $output->writeln("The environment <info>$environmentId</info> is already active.");
+                $processed++;
+                continue;
+            }
+            if (!$this->operationAllowed('activate', $environment)) {
+                $output->writeln("Operation not permitted: The environment <error>$environmentId</error> can't be activated.");
+                continue;
+            }
+            $question = "Are you sure you want to activate the environment <info>$environmentId</info>?";
+            if (!$questionHelper->confirm($question, $input, $output)) {
+                continue;
+            }
+            $process[$environmentId] = $environment;
+        }
+        foreach ($process as $environmentId =>  $environment) {
+            $client = $this->getPlatformClient($environment['endpoint']);
+            try {
+                $client->activateEnvironment();
+                $processed++;
+                $output->writeln("Activated environment <info>$environmentId</info>");
+            }
+            catch (\Exception $e) {
+                $output->writeln($e->getMessage());
+            }
+        }
+        return $processed >= $count;
+    }
+
 }

--- a/src/Command/EnvironmentActivateCommand.php
+++ b/src/Command/EnvironmentActivateCommand.php
@@ -2,6 +2,7 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -12,7 +13,8 @@ class EnvironmentActivateCommand extends EnvironmentCommand
     {
         $this
             ->setName('environment:activate')
-            ->setDescription('Activate an environment');
+            ->setDescription('Activate an environment')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment to activate');
         $this->addProjectOption()->addEnvironmentOption();
     }
 

--- a/src/Command/EnvironmentActivateCommand.php
+++ b/src/Command/EnvironmentActivateCommand.php
@@ -81,6 +81,9 @@ class EnvironmentActivateCommand extends EnvironmentCommand
                 $output->writeln($e->getMessage());
             }
         }
+        if ($processed) {
+            $this->getEnvironments($this->project, true);
+        }
         return $processed >= $count;
     }
 

--- a/src/Command/EnvironmentBackupCommand.php
+++ b/src/Command/EnvironmentBackupCommand.php
@@ -2,8 +2,8 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentBackupCommand extends EnvironmentCommand
@@ -13,7 +13,8 @@ class EnvironmentBackupCommand extends EnvironmentCommand
     {
         $this
             ->setName('environment:backup')
-            ->setDescription('Make a backup of an environment');
+            ->setDescription('Make a backup of an environment')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment to back up');
         $this->addProjectOption()->addEnvironmentOption();
     }
 

--- a/src/Command/EnvironmentBranchCommand.php
+++ b/src/Command/EnvironmentBranchCommand.php
@@ -23,6 +23,7 @@ class EnvironmentBranchCommand extends EnvironmentCommand
                 InputArgument::OPTIONAL,
                 'The name of the new environment. For example: "Sprint 2"'
             )
+            ->addArgument('parent', InputArgument::OPTIONAL, 'The parent of the new environment')
             ->addOption(
                 'force',
                 null,
@@ -40,7 +41,7 @@ class EnvironmentBranchCommand extends EnvironmentCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$this->validateInput($input, $output)) {
+        if (!$this->validateInput($input, $output, 'parent')) {
             return 1;
         }
 

--- a/src/Command/EnvironmentDeactivateCommand.php
+++ b/src/Command/EnvironmentDeactivateCommand.php
@@ -2,8 +2,8 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentDeactivateCommand extends EnvironmentCommand
@@ -13,7 +13,8 @@ class EnvironmentDeactivateCommand extends EnvironmentCommand
     {
         $this
             ->setName('environment:deactivate')
-            ->setDescription('Deactivate an environment');
+            ->setDescription('Deactivate an environment')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment to deactivate');
         $this->addProjectOption()->addEnvironmentOption();
     }
 

--- a/src/Command/EnvironmentDeactivateCommand.php
+++ b/src/Command/EnvironmentDeactivateCommand.php
@@ -15,18 +15,18 @@ class EnvironmentDeactivateCommand extends EnvironmentCommand
         $this
           ->setName('environment:deactivate')
           ->setDescription('Deactivate an environment')
-          ->addArgument('environments', InputArgument::IS_ARRAY, 'The environment(s) to deactivate')
+          ->addArgument('environment', InputArgument::IS_ARRAY, 'The environment(s) to deactivate')
           ->addOption('merged', null, InputOption::VALUE_NONE, 'Deactivate all merged environments');
         $this->addProjectOption()->addEnvironmentOption();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$this->validateInput($input, $output, 'environments')) {
+        if (!$this->validateInput($input, $output)) {
             return 1;
         }
 
-        $environments = $input->getArgument('environments') ?: array($this->environment);
+        $environments = $this->environment ? array($this->environment) : $input->getArgument('environment');
 
         if ($input->getOption('merged')) {
             $parent = reset($environments);

--- a/src/Command/EnvironmentDeactivateCommand.php
+++ b/src/Command/EnvironmentDeactivateCommand.php
@@ -111,6 +111,9 @@ class EnvironmentDeactivateCommand extends EnvironmentCommand
                 $output->writeln($e->getMessage());
             }
         }
+        if ($deactivated) {
+            $this->getEnvironments($this->project, true);
+        }
         return $deactivated >= $count;
     }
 

--- a/src/Command/EnvironmentDeleteCommand.php
+++ b/src/Command/EnvironmentDeleteCommand.php
@@ -2,8 +2,8 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentDeleteCommand extends EnvironmentCommand
@@ -13,7 +13,8 @@ class EnvironmentDeleteCommand extends EnvironmentCommand
     {
         $this
             ->setName('environment:delete')
-            ->setDescription('Delete an environment');
+            ->setDescription('Delete an environment')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment to delete');
         $this->addProjectOption()->addEnvironmentOption();
     }
 

--- a/src/Command/EnvironmentMergeCommand.php
+++ b/src/Command/EnvironmentMergeCommand.php
@@ -2,6 +2,7 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -13,7 +14,8 @@ class EnvironmentMergeCommand extends EnvironmentCommand
         $this
             ->setName('environment:merge')
             ->setAliases(array('merge'))
-            ->setDescription('Merge an environment');
+            ->setDescription('Merge an environment')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment to merge');
         $this->addProjectOption()->addEnvironmentOption();
     }
 

--- a/src/Command/EnvironmentRelationshipsCommand.php
+++ b/src/Command/EnvironmentRelationshipsCommand.php
@@ -3,6 +3,7 @@
 namespace CommerceGuys\Platform\Cli\Command;
 
 use CommerceGuys\Platform\Cli\Model\Environment;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -15,7 +16,8 @@ class EnvironmentRelationshipsCommand extends PlatformCommand
     {
         $this
             ->setName('environment:relationships')
-            ->setDescription('List the environment\'s relationships');
+            ->setDescription('List an environment\'s relationships')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment');
         $this->addProjectOption()->addEnvironmentOption();
         // $this->ignoreValidationErrors(); @todo: Pass extra stuff to ssh? -i?
     }

--- a/src/Command/EnvironmentSynchronizeCommand.php
+++ b/src/Command/EnvironmentSynchronizeCommand.php
@@ -4,7 +4,6 @@ namespace CommerceGuys\Platform\Cli\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentSynchronizeCommand extends EnvironmentCommand

--- a/src/Command/EnvironmentUrlCommand.php
+++ b/src/Command/EnvironmentUrlCommand.php
@@ -4,7 +4,6 @@ namespace CommerceGuys\Platform\Cli\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentUrlCommand extends UrlCommandBase

--- a/src/Command/PlatformCommand.php
+++ b/src/Command/PlatformCommand.php
@@ -594,16 +594,24 @@ abstract class PlatformCommand extends Command
     /**
      * @param InputInterface  $input
      * @param OutputInterface $output
+     * @param string $envArgName
      *
      * @return bool
      */
-    protected function validateInput(InputInterface $input, OutputInterface $output)
+    protected function validateInput(InputInterface $input, OutputInterface $output, $envArgName = 'environment')
     {
         $projectId = $input->hasOption('project') ? $input->getOption('project') : null;
         try {
             $this->project = $this->selectProject($projectId);
-            if ($input->hasOption('environment')) {
-                $this->environment = $this->selectEnvironment($input->getOption('environment'));
+            $envOptionName = 'environment';
+            if ($input->hasArgument($envArgName) && $input->getArgument($envArgName)) {
+                if ($input->hasOption($envOptionName) && $input->getOption($envOptionName)) {
+                    throw new \InvalidArgumentException(sprintf("You cannot use both the '%s' argument and the '--%s' option", $envArgName, $envOptionName));
+                }
+                $this->environment = $this->selectEnvironment($input->getArgument($envArgName));
+            }
+            elseif ($input->hasOption($envOptionName)) {
+                $this->environment = $this->selectEnvironment($input->getOption($envOptionName));
             }
         }
         catch (\RuntimeException $e) {

--- a/src/Command/PlatformCommand.php
+++ b/src/Command/PlatformCommand.php
@@ -608,7 +608,10 @@ abstract class PlatformCommand extends Command
                 if ($input->hasOption($envOptionName) && $input->getOption($envOptionName)) {
                     throw new \InvalidArgumentException(sprintf("You cannot use both the '%s' argument and the '--%s' option", $envArgName, $envOptionName));
                 }
-                $this->environment = $this->selectEnvironment($input->getArgument($envArgName));
+                $argument = $input->getArgument($envArgName);
+                if (!is_array($argument)) {
+                    $this->environment = $this->selectEnvironment($argument);
+                }
             }
             elseif ($input->hasOption($envOptionName)) {
                 $this->environment = $this->selectEnvironment($input->getOption($envOptionName));


### PR DESCRIPTION
Adds an 'environment' argument (rather than an option) to these commands:
```
platform environment:activate [--environment my-env]
  => platform environment:activate [my-env] [my-env2] [my-env3] [...]

platform environment:backup [--environment my-env]
  => platform environment:backup [my-env]

platform environment:deactivate [--environment my-env]
  => platform environment:deactivate [my-env] [my-env2] [my-env3] [...]

platform environment:delete [--environment my-env]
  => platform environment:delete [my-env] [my-env2] [my-env3] [...]

platform branch new-env [--environment parent-env]
  => platform branch new-env [parent-env]

platform environment:merge [--environment my-env]
  => platform environment:merge [my-env]
```

Also allows the following commands to work with multiple environments:
 * environment:activate
 * environment:deactivate (plus a new `--merged` option to deactivate all merged branches)
 * environment:delete (plus a new `--inactive` option to delete all inactive environments)

Unfortunately some commands cannot have this treatment, because they already take an argument. These are:
* environment:synchronize
* environment:url