### PR TITLE
Generate an SSH key for the user

### DIFF
--- a/src/Command/SshKeyAddCommand.php
+++ b/src/Command/SshKeyAddCommand.php
@@ -4,6 +4,7 @@ namespace CommerceGuys\Platform\Cli\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Process\Process;
@@ -16,42 +17,97 @@ class SshKeyAddCommand extends PlatformCommand
         $this
             ->setName('ssh-key:add')
             ->setDescription('Add a new SSH key')
-            ->addArgument(
-                'path',
-                InputArgument::OPTIONAL,
-                'The path to the ssh key'
-            );
+            ->addArgument('path', InputArgument::OPTIONAL, 'The path to an existing SSH key. Leave blank to generate a new key')
+            ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'A name to identify the key');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $questionHelper = $this->getHelper('question');
+
         $path = $input->getArgument('path');
         if (empty($path)) {
-            $output->writeln("<error>You must specify the path to the key.</error>");
-            return 1;
+            $shellHelper = $this->getHelper('shell');
+            $default = $this->getDefaultKeyFilename();
+            $defaultPath = "$default.pub";
+
+            // Look for an existing local key.
+            if (file_exists($defaultPath) && $questionHelper->confirm("Use existing local key <info>" . basename($defaultPath). "</info>?", $input, $output)) {
+                $path = $defaultPath;
+            }
+            // Offer to generate a key.
+            elseif ($shellHelper->commandExists('ssh-keygen') && $questionHelper->confirm("Generate a new key?", $input, $output)) {
+                $newKey = $this->getNewKeyFilename($default);
+                $args = array('ssh-keygen', '-t', 'rsa', '-f', $newKey, '-N', '');
+                $shellHelper->execute($args, null, true);
+                $path = "$newKey.pub";
+                $output->writeln("Generated a new key: $path");
+            }
+            else {
+                $output->writeln("<error>You must specify the path to a public SSH key</error>");
+                return 1;
+            }
+
         }
+
         if (!file_exists($path)) {
-            $output->writeln("<error>Key not found.<error>");
+            $output->writeln("File not found: <error>$path<error>");
             return 1;
         }
 
         $process = new Process('ssh-keygen -l -f ' . escapeshellarg($path));
         $process->run();
         if ($process->getExitCode() == 1) {
-            $output->writeln("<error>The file does not contain a valid key.</error>");
+            $output->writeln("The file does not contain a valid public key: <error>$path</error>");
             return 1;
         }
 
         $key = file_get_contents($path);
-        $helper = $this->getHelper('question');
-        $title = $helper->ask($input, $output, new Question('Enter a name for the key: '));
+
+        $name = $input->getOption('name');
+        if (!$name) {
+            $name = $questionHelper->ask($input, $output, new Question('Enter a name for the key: '));
+        }
 
         $client = $this->getAccountClient();
-        $client->createSshKey(array('title' => $title, 'value' => $key));
+        $client->createSshKey(array('title' => $name, 'value' => $key));
 
-        $message = '<info>';
-        $message .= "\nThe given key has been successfully added. \n";
-        $message .= "</info>";
-        $output->writeln($message);
+        $output->writeln('The SSH key <info>' . basename($path) . '</info> has been successfully added to your Platform.sh account');
+        return 0;
     }
+
+    /**
+     * The path to the user's key that we expect to be used with Platform.sh.
+     *
+     * @return string
+     */
+    protected function getDefaultKeyFilename()
+    {
+        $home = $this->getHelper('fs')->getHomeDirectory();
+        return "$home/.ssh/platform_sh.key";
+    }
+
+    /**
+     * Find the path for a new SSH key.
+     *
+     * If the file already exists, this will recurse to find a new filename.
+     *
+     * @param string $base
+     * @param int $number
+     *
+     * @return string
+     */
+    protected function getNewKeyFilename($base, $number = 1)
+    {
+        $base = $base ?: $this->getDefaultKeyFilename();
+        $filename = $base;
+        if ($number > 1) {
+            $filename = strpos($base, '.key') ? str_replace('.key', ".$number.key", $base) : "$base.$number";
+        }
+        if (file_exists($filename)) {
+            return $this->getNewKeyFilename($base, ++$number);
+        }
+        return $filename;
+    }
+
 }

--- a/src/Command/SshKeyDeleteCommand.php
+++ b/src/Command/SshKeyDeleteCommand.php
@@ -24,16 +24,14 @@ class SshKeyDeleteCommand extends PlatformCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $id = $input->getArgument('id');
-        if (empty($id)) {
-            $output->writeln("<error>You must specify the ID of the key to delete.</error>");
-            return;
+        if (empty($id) || !is_numeric($id)) {
+            $output->writeln("<error>You must specify the ID of the key to delete</error>");
+            return 1;
         }
         $client = $this->getAccountClient();
         $client->deleteSshKey(array('id' => $id));
 
-        $message = '<info>';
-        $message .= "\nThe SSH key #$id has been deleted. \n";
-        $message .= "</info>";
-        $output->writeln($message);
+        $output->writeln("The SSH key <info>#$id</info> has been deleted from your Platform.sh account");
+        return 0;
     }
 }

--- a/src/Command/SshKeyListCommand.php
+++ b/src/Command/SshKeyListCommand.php
@@ -14,7 +14,7 @@ class SshKeyListCommand extends PlatformCommand
         $this
             ->setName('ssh-key:list')
             ->setAliases(array('ssh-keys'))
-            ->setDescription('Get a list of all added SSH keys');
+            ->setDescription('Get a list of SSH keys in your account');
         ;
     }
 
@@ -22,22 +22,22 @@ class SshKeyListCommand extends PlatformCommand
     {
         $client = $this->getAccountClient();
         $data = $client->getSshKeys();
-        $key_rows = array();
-        foreach ($data['keys'] as $key) {
-            $key_row = array();
-            $key_row[] = $key['id'];
-            $key_row[] = $key['title'] . ' (' . $key['fingerprint'] . ')';
-            $key_rows[] = $key_row;
+
+        if (!empty($data['keys'])) {
+            $output->writeln("Your SSH keys are:");
+            $table = new Table($output);
+            $headers = array('ID', 'Title', 'Fingerprint');
+            $rows = array();
+            foreach ($data['keys'] as $key) {
+                $rows[] = array($key['id'], $key['title'], $key['fingerprint']);
+            }
+            $table->setHeaders($headers);
+            $table->addRows($rows);
+            $table->render();
+            $output->writeln('');
         }
 
-        $output->writeln("\nYour SSH keys are: ");
-        $table = new Table($output);
-        $table
-            ->setHeaders(array('ID', 'Key'))
-            ->addRows($key_rows);
-        $table->render();
-
-        $output->writeln("\nAdd a new SSH key by running <info>platform ssh-key:add [path]</info>.");
-        $output->writeln("Delete an SSH key by running <info>platform ssh-key:delete [id]</info>.\n");
+        $output->writeln("Add a new SSH key by running <info>platform ssh-key:add [path]</info>");
+        $output->writeln("Delete an SSH key by running <info>platform ssh-key:delete [id]</info>");
     }
 }


### PR DESCRIPTION
Based on Ori's work (https://github.com/platformsh/platformsh-cli/issues/74#issuecomment-65207224)

Type `platform ssh-key:add` (with no arguments) to generate an SSH key and add it to your Platform.sh account. This would save time for those who haven't memorised the appropriate `ssh-keygen` command.

If you include `--yes` then it will happen non-interactively - this may at least be useful in future for scripted use, particularly when we support multiple accounts.

![screen shot 2015-02-01 at 10 09 30](https://cloud.githubusercontent.com/assets/1465106/5991744/82d1a616-a9fa-11e4-9196-9142a2a30745.png)

You can still specify a path to your preferred public key as before: `platform ssh-key:add ~/.ssh/id_rsa.pub`