### PR TITLE
Show more iformation in the welcome message for current project

### DIFF
--- a/src/Command/WelcomeCommand.php
+++ b/src/Command/WelcomeCommand.php
@@ -36,7 +36,11 @@ class WelcomeCommand extends PlatformCommand
         if ($currentProject = $this->getCurrentProject()) {
             // The project is known. Show the environments.
             $projectName = $currentProject['name'];
-            $output->writeln("\nYour project is <info>$projectName</info>.\n");
+            $projectURI = $currentProject['uri'];
+            $projectId = $currentProject['id'];
+            $output->writeln("\nProject Name: <info>$projectName</info>");
+            $output->writeln("Project ID: <info>$projectId</info>");
+            $output->writeln("Project Dashboard: <info>$projectURI</info>\n");
             $envInput = new ArrayInput(array(
                 'command' => 'environments',
                 '--refresh' => 0,


### PR DESCRIPTION
It would be helpful to have the project URI and ID displayed whenever running the platform command within the context of a project. 