### PR TITLE
[WIP] Allow SSH/drush into a specific remote app

### DIFF
--- a/src/Command/EnvironmentDrushCommand.php
+++ b/src/Command/EnvironmentDrushCommand.php
@@ -21,7 +21,7 @@ class EnvironmentDrushCommand extends PlatformCommand
             ->setAliases(array('drush'))
             ->setDescription('Run a drush command on the remote environment')
             ->addArgument('cmd', InputArgument::OPTIONAL, 'A command and arguments to pass to Drush', 'status');
-        $this->addProjectOption()->addEnvironmentOption();
+        $this->addProjectOption()->addEnvironmentOption()->addAppOption();
         $this->ignoreValidationErrors();
     }
 
@@ -74,7 +74,7 @@ class EnvironmentDrushCommand extends PlatformCommand
         }
 
         $environment = new Environment($this->environment);
-        $sshUrl = $environment->getSshUrl();
+        $sshUrl = $environment->getSshUrl($input->getOption('app'));
 
         $appRoot = '/app/public';
         $dimensions = $this->getApplication()->getTerminalDimensions();

--- a/src/Command/EnvironmentDrushCommand.php
+++ b/src/Command/EnvironmentDrushCommand.php
@@ -73,10 +73,12 @@ class EnvironmentDrushCommand extends PlatformCommand
             $sshOptions .= ' -q';
         }
 
-        $environment = new Environment($this->environment);
-        $sshUrl = $environment->getSshUrl($input->getOption('app'));
+        $app = $input->getOption('app');
 
-        $appRoot = '/app/public';
+        $environment = new Environment($this->environment);
+        $sshUrl = $environment->getSshUrl($app);
+
+        $appRoot = '/app/' . ($app ?: 'public');
         $dimensions = $this->getApplication()->getTerminalDimensions();
         $columns = $dimensions[0] ?: 80;
         $sshDrushCommand = "COLUMNS=$columns drush -r $appRoot";

--- a/src/Command/EnvironmentDrushCommand.php
+++ b/src/Command/EnvironmentDrushCommand.php
@@ -73,12 +73,10 @@ class EnvironmentDrushCommand extends PlatformCommand
             $sshOptions .= ' -q';
         }
 
-        $app = $input->getOption('app');
-
         $environment = new Environment($this->environment);
-        $sshUrl = $environment->getSshUrl($app);
+        $sshUrl = $environment->getSshUrl($input->getOption('app'));
 
-        $appRoot = '/app/' . ($app ?: 'public');
+        $appRoot = '/app/public';
         $dimensions = $this->getApplication()->getTerminalDimensions();
         $columns = $dimensions[0] ?: 80;
         $sshDrushCommand = "COLUMNS=$columns drush -r $appRoot";

--- a/src/Command/EnvironmentRelationshipsCommand.php
+++ b/src/Command/EnvironmentRelationshipsCommand.php
@@ -18,7 +18,7 @@ class EnvironmentRelationshipsCommand extends PlatformCommand
             ->setName('environment:relationships')
             ->setDescription('List an environment\'s relationships')
             ->addArgument('environment', InputArgument::OPTIONAL, 'The environment');
-        $this->addProjectOption()->addEnvironmentOption();
+        $this->addProjectOption()->addEnvironmentOption()->addAppOption();
         // $this->ignoreValidationErrors(); @todo: Pass extra stuff to ssh? -i?
     }
 
@@ -30,7 +30,7 @@ class EnvironmentRelationshipsCommand extends PlatformCommand
 
         $environment = new Environment($this->environment);
 
-        $args = array('ssh', $environment->getSshUrl(), 'echo $PLATFORM_RELATIONSHIPS');
+        $args = array('ssh', $environment->getSshUrl($input->getOption('app')), 'echo $PLATFORM_RELATIONSHIPS');
         $relationships = $this->getHelper('shell')->execute($args, null, true);
 
         if (!$relationships) {

--- a/src/Command/EnvironmentSshCommand.php
+++ b/src/Command/EnvironmentSshCommand.php
@@ -23,7 +23,7 @@ class EnvironmentSshCommand extends PlatformCommand
             ->addArgument('cmd', InputArgument::OPTIONAL, 'A command to run on the environment.')
             ->addOption('pipe', NULL, InputOption::VALUE_NONE, "Output the SSH URL only.")
             ->setDescription('SSH to the current environment');
-        $this->addProjectOption()->addEnvironmentOption();
+        $this->addProjectOption()->addEnvironmentOption()->addAppOption();
         $this->ignoreValidationErrors();
     }
 
@@ -34,7 +34,7 @@ class EnvironmentSshCommand extends PlatformCommand
         }
 
         $environment = new Environment($this->environment);
-        $sshUrl = $environment->getSshUrl();
+        $sshUrl = $environment->getSshUrl($input->getOption('app'));
 
         $command = $input->getArgument('cmd');
         if ($input instanceof ArgvInput) {

--- a/src/Command/PlatformCommand.php
+++ b/src/Command/PlatformCommand.php
@@ -501,6 +501,16 @@ abstract class PlatformCommand extends Command
     }
 
     /**
+     * Add the --app option.
+     *
+     * @return self
+     */
+    protected function addAppOption()
+    {
+        return $this->addOption('app', null, InputOption::VALUE_OPTIONAL, 'The remote application name');
+    }
+
+    /**
      * @param string $projectId
      * @return array
      */

--- a/src/Model/Environment.php
+++ b/src/Model/Environment.php
@@ -9,11 +9,13 @@ class Environment extends HalResource
     /**
      * Get the SSH URL for the environment.
      *
+     * @param string $app An application name.
+     *
      * @throws \Exception
      *
      * @return string
      */
-    public function getSshUrl()
+    public function getSshUrl($app = '')
     {
         if (!isset($this->data['_links']['ssh']['href'])) {
             $id = $this->data['id'];
@@ -23,6 +25,10 @@ class Environment extends HalResource
         $sshUrl = parse_url($this->data['_links']['ssh']['href']);
         $host = $sshUrl['host'];
         $user = $sshUrl['user'];
+
+        if ($app) {
+            $user .= '--' . $app;
+        }
 
         return $user . '@' . $host;
     }


### PR DESCRIPTION
 - [x] these SSH URLs don't work yet anyway (see ticket 1811)
 - [ ] we need a good way of determining the remote document_root for the drush command to work (i.e. an `environment/<id>/applications` API)