### PR TITLE
Display the command name and aliases in the command's help.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -75,8 +75,9 @@ class Application extends ParentApplication {
      */
     protected function getDefaultCommands()
     {
-        // Override the default commands to add a custom ListCommand.
-        return array(new HelpCommand(), new Command\ListCommand());
+        // Override the default commands to add a custom HelpCommand and
+        // ListCommand.
+        return array(new Command\HelpCommand(), new Command\ListCommand());
     }
 
     /**

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @file
+ * Override Symfony Console's HelpCommand to customize the appearance of help.
+ */
+
+namespace CommerceGuys\Platform\Cli\Command;
+
+use CommerceGuys\Platform\Cli\CustomTextDescriptor;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\HelpCommand as ParentHelpCommand;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class HelpCommand extends ParentHelpCommand
+{
+
+    protected $command;
+
+    /**
+     * @inheritdoc
+     */
+    public function setCommand(Command $command)
+    {
+        $this->command = $command;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (null === $this->command) {
+            $this->command = $this->getApplication()->find($input->getArgument('command_name'));
+        }
+
+        if ($input->getOption('xml')) {
+            $input->setOption('format', 'xml');
+        }
+
+        $helper = new DescriptorHelper();
+        $helper->register('txt', new CustomTextDescriptor());
+        $helper->describe($output, $this->command, array(
+          'format' => $input->getOption('format'),
+          'raw'    => $input->getOption('raw'),
+        ));
+    }
+
+}

--- a/src/CustomTextDescriptor.php
+++ b/src/CustomTextDescriptor.php
@@ -1,7 +1,8 @@
 <?php
 /**
  * @file
- * Override Symfony Console's TextDescriptor to customize the command list.
+ * Override Symfony Console's TextDescriptor to customize the appearance of the
+ * command list and each command's help.
  */
 
 namespace CommerceGuys\Platform\Cli;
@@ -14,6 +15,44 @@ use Symfony\Component\Console\Application as ConsoleApplication;
 
 class CustomTextDescriptor extends TextDescriptor
 {
+
+    /**
+     * @inheritdoc
+     */
+    protected function describeCommand(Command $command, array $options = array())
+    {
+        $command->getSynopsis();
+        $command->mergeApplicationDefinition(false);
+
+        $this->writeText("<comment>Command:</comment> " . $command->getName(), $options);
+        if ($aliases = $command->getAliases()) {
+            $this->writeText("\n");
+            $this->writeText('<comment>Aliases:</comment> ' . implode(', ', $aliases), $options);
+        }
+        if ($description = $command->getDescription()) {
+            $this->writeText("\n");
+            $this->writeText("<comment>Description:</comment> $description", $options);
+        }
+        $this->writeText("\n\n");
+
+        $this->writeText('<comment>Usage:</comment>', $options);
+        $this->writeText("\n");
+        $this->writeText(' '.$command->getSynopsis(), $options);
+        $this->writeText("\n");
+
+        if ($definition = $command->getNativeDefinition()) {
+            $this->writeText("\n");
+            $this->describeInputDefinition($definition, $options);
+        }
+
+        if ($help = $command->getProcessedHelp()) {
+            $this->writeText("\n");
+            $this->writeText('<comment>Help:</comment>', $options);
+            $this->writeText("\n");
+            $this->writeText(' '.str_replace("\n", "\n ", $help), $options);
+            $this->writeText("\n");
+        }
+    }
 
     /**
      * @inheritdoc


### PR DESCRIPTION
Again, it's not my fault... you do really need this much code just to override a small aspect of Symfony's behaviour.