### PR TITLE
Support build/deploy hooks in a .platform.app.local.yaml file

### DIFF
--- a/src/Command/ProjectBuildCommand.php
+++ b/src/Command/ProjectBuildCommand.php
@@ -35,6 +35,11 @@ class ProjectBuildCommand extends PlatformCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Do not create or use a build archive'
+            )->addOption(
+                'no-deploy-hooks',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not run local deploy hooks'
             );
         $projectRoot = $this->getProjectRoot();
         if (!$projectRoot || Drupal::isDrupal($projectRoot . '/' . LocalProject::REPOSITORY_DIR)) {
@@ -107,6 +112,7 @@ class ProjectBuildCommand extends PlatformCommand
           'noArchive' => 'no-archive',
           'noCache' => 'no-cache',
           'noClean' => 'no-clean',
+          'noDeployHooks' => 'no-deploy-hooks',
         );
         foreach ($settingsMap as $setting => $option) {
             $settings[$setting] = $input->hasOption($option) && $input->getOption($option);


### PR DESCRIPTION
Addresses #232 

An example .platform.app.local.yaml file might be:
```yaml
hooks:
    build: |
        mv profiles/my_profile/my_file.txt my_file.txt
    deploy: |
        drush -y updb
        drush cc drush
        drush -y fra
```

and the output would look like:
```
Running local build hook(s)
Saving build archive...
Running local deploy hook(s)
No database updates required                                                                                        [success]
'all' cache was cleared.                                                                                            [success]
Finished performing updates.                                                                                        [ok]
'drush' cache was cleared.                                                                                          [success]
Current state already matches defaults, aborting.                                                                   [ok]
```

... you could even miss out the `-y` if you want to have confirmation prompts