### PR TITLE
Support API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Global options:
   --version        -V Display this application version
   --yes            -y Answer "yes" to all prompts
   --no             -n Answer "no" to all prompts
+  --session-id        Specify the session ID
+  --api-token         Specify an API token file
   --shell          -s Launch the shell
 
 Available commands:

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ Global options:
   --version        -V Display this application version
   --yes            -y Answer "yes" to all prompts
   --no             -n Answer "no" to all prompts
-  --session-id        Specify the session ID
-  --api-token         Specify an API token file
   --shell          -s Launch the shell
 
 Available commands:
@@ -164,6 +162,18 @@ variable
 The CLI caches details of your projects and their environments. These caches
 could become out-of-date. You can get a fresh list of projects or environments
 with the `platform projects` and `platform environments` commands.
+
+### Customization
+
+You can configure the CLI via these environment variables:
+
+* `PLATFORMSH_CLI_API_TOKEN`: a filename containing an API token (default 0)
+* `PLATFORMSH_CLI_DEBUG`: set to 1 to enable cURL debugging (default 0)
+* `PLATFORMSH_CLI_DISABLE_CACHE`: set to 1 to disable caching (default 0)
+* `PLATFORMSH_CLI_DRUSH`: configure the Drush executable to use (default 'drush')
+* `PLATFORMSH_CLI_ENVIRONMENTS_TTL`: the cache TTL for environments, in seconds (default 600)
+* `PLATFORMSH_CLI_PROJECTS_TTL`: the cache TTL for projects, in seconds (default 3600)
+* `PLATFORMSH_CLI_SESSION_ID`: change user (default 'default')
 
 ### Credits
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -50,6 +50,7 @@ class Application extends ParentApplication
             new InputOption('--yes', '-y', InputOption::VALUE_NONE, 'Answer "yes" to all prompts'),
             new InputOption('--no', '-n', InputOption::VALUE_NONE, 'Answer "no" to all prompts'),
             new InputOption('--session-id', null, InputOption::VALUE_OPTIONAL, 'Specify the session ID'),
+            new InputOption('--api-token', null, InputOption::VALUE_OPTIONAL, 'Specify an API token file'),
             new InputOption('--shell', '-s', InputOption::VALUE_NONE, 'Launch the shell'),
           )
         );

--- a/src/Application.php
+++ b/src/Application.php
@@ -49,8 +49,6 @@ class Application extends ParentApplication
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
             new InputOption('--yes', '-y', InputOption::VALUE_NONE, 'Answer "yes" to all prompts'),
             new InputOption('--no', '-n', InputOption::VALUE_NONE, 'Answer "no" to all prompts'),
-            new InputOption('--session-id', null, InputOption::VALUE_OPTIONAL, 'Specify the session ID'),
-            new InputOption('--api-token', null, InputOption::VALUE_OPTIONAL, 'Specify an API token file'),
             new InputOption('--shell', '-s', InputOption::VALUE_NONE, 'Launch the shell'),
           )
         );

--- a/src/Command/EnvironmentBranchCommand.php
+++ b/src/Command/EnvironmentBranchCommand.php
@@ -64,7 +64,6 @@ class EnvironmentBranchCommand extends PlatformCommand
                 // List environments.
                 $params = array(
                   'command' => 'environments',
-                  '--session-id' => self::$sessionId,
                   '--project' => $this->getSelectedProject()['id'],
                 );
 

--- a/src/Command/PlatformLoginCommand.php
+++ b/src/Command/PlatformLoginCommand.php
@@ -18,6 +18,11 @@ class PlatformLoginCommand extends PlatformCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // Disable the API token for this command.
+        if (isset(self::$apiToken)) {
+            throw new \Exception('Cannot log in: an API token is set');
+        }
+        // Login can only happen during interactive use.
         if (!$input->isInteractive()) {
             throw new \Exception('Non-interactive login not supported');
         }

--- a/src/Command/WelcomeCommand.php
+++ b/src/Command/WelcomeCommand.php
@@ -26,6 +26,10 @@ class WelcomeCommand extends PlatformCommand
     {
         $output->writeln("Welcome to Platform.sh!\n");
 
+        // Ensure the user is logged in in this parent command, because the
+        // delegated commands below will not have interactive input.
+        $this->getClient();
+
         $application = $this->getApplication();
 
         if ($currentProject = $this->getCurrentProject()) {

--- a/src/Command/WelcomeCommand.php
+++ b/src/Command/WelcomeCommand.php
@@ -43,7 +43,6 @@ class WelcomeCommand extends PlatformCommand
             $envInput = new ArrayInput(
               array(
                 'command' => 'environments',
-                '--session-id' => self::$sessionId,
                 '--refresh' => 0,
               )
             );
@@ -56,7 +55,6 @@ class WelcomeCommand extends PlatformCommand
             $projectsInput = new ArrayInput(
               array(
                 'command' => 'projects',
-                '--session-id' => self::$sessionId,
                 '--refresh' => 0,
               )
             );

--- a/src/Helper/DrushHelper.php
+++ b/src/Helper/DrushHelper.php
@@ -54,7 +54,8 @@ class DrushHelper extends Helper
     {
         exec($this->getDrushExecutable() . ' --version', $drushVersion, $returnCode);
         if ($returnCode && $returnCode === 127) {
-            if ($attemptInstall && $this->install()) {
+            // Retry installing, if the default Drush does not exist.
+            if ($attemptInstall && !getenv('PLATFORMSH_CLI_DRUSH') && $this->install()) {
                 $this->ensureInstalled($minVersion, false);
 
                 return;

--- a/src/Helper/DrushHelper.php
+++ b/src/Helper/DrushHelper.php
@@ -128,8 +128,8 @@ class DrushHelper extends Helper
      */
     public function getDrushExecutable()
     {
-        if (getenv('PLATFORM_CLI_DRUSH')) {
-            return getenv('PLATFORM_CLI_DRUSH');
+        if (getenv('PLATFORMSH_CLI_DRUSH')) {
+            return getenv('PLATFORMSH_CLI_DRUSH');
         }
 
         $executable = 'drush';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,4 +8,4 @@ require __DIR__ . '/../vendor/autoload.php';
 
 define('CLI_ROOT', dirname(__DIR__));
 
-putenv('PLATFORM_CLI_DRUSH=' . CLI_ROOT . '/vendor/bin/drush');
+putenv('PLATFORMSH_CLI_DRUSH=' . CLI_ROOT . '/vendor/bin/drush');


### PR DESCRIPTION
Changes configuration to use environment variables (removes `--session-id` option)

```bash
export PLATFORMSH_CLI_API_TOKEN=~/.my-api-token
platform projects
```