### PR TITLE
platform url should get the HTTPS URL of an environment

### DIFF
--- a/src/Command/Environment/EnvironmentUrlCommand.php
+++ b/src/Command/Environment/EnvironmentUrlCommand.php
@@ -31,11 +31,35 @@ class EnvironmentUrlCommand extends UrlCommandBase
 
         $selectedEnvironment = $this->getSelectedEnvironment();
 
-        if (!$selectedEnvironment->hasLink('public-url')) {
-            throw new \Exception('No URL available');
+        $urls = $selectedEnvironment->getRouteUrls();
+        if (empty($urls)) {
+            $output->writeln("No URLs found");
+            return 1;
         }
 
-        $url = $selectedEnvironment->getLink('public-url', true);
+        // Sort the URLs heuristically. Prefer short URLs with HTTPS.
+        usort($urls, function ($a, $b) {
+            $result = 0;
+            if (parse_url($a, PHP_URL_SCHEME) === 'https') {
+                $result -= 2;
+            }
+            if (parse_url($b, PHP_URL_SCHEME) === 'https') {
+                $result += 2;
+            }
+            $result += strlen($a) <= strlen($b) ? -1 : 1;
+
+            return $result;
+        });
+
+        // Select a default.
+        $url = $urls[0];
+
+        // Allow the user to choose a URL.
+        if ($input->getOption('browser') == 0) {
+            /** @var \Platformsh\Cli\Helper\PlatformQuestionHelper $questionHelper */
+            $questionHelper = $this->getHelper('question');
+            $url = $questionHelper->choose(array_combine($urls, $urls), 'Enter a number to choose a URL', $input, $output, $url);
+        }
 
         $path = $input->getArgument('path');
         if ($path) {
@@ -43,5 +67,7 @@ class EnvironmentUrlCommand extends UrlCommandBase
         }
 
         $this->openUrl($url, $input, $output);
+
+        return 0;
     }
 }


### PR DESCRIPTION
This adds an heuristic to look through the environment's routes to find an HTTPS URL.

... or perhaps this should wait until there is a way to specify a default route.