### PR TITLE
Automatically wait for environment activation when needed

### DIFF
--- a/src/Command/EnvironmentDrushCommand.php
+++ b/src/Command/EnvironmentDrushCommand.php
@@ -8,6 +8,7 @@ use Platformsh\Cli\Local\Toolstack\Drupal;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentDrushCommand extends PlatformCommand
@@ -19,7 +20,8 @@ class EnvironmentDrushCommand extends PlatformCommand
           ->setName('environment:drush')
           ->setAliases(array('drush'))
           ->setDescription('Run a drush command on the remote environment')
-          ->addArgument('cmd', InputArgument::OPTIONAL, 'A command and arguments to pass to Drush', 'status');
+          ->addArgument('cmd', InputArgument::OPTIONAL, 'A command and arguments to pass to Drush', 'status')
+          ->addOption('no-wait', null, InputOption::VALUE_NONE, "Do not wait for the environment to become active first");
         $this->addProjectOption()
              ->addEnvironmentOption()
              ->addAppOption();
@@ -73,6 +75,9 @@ class EnvironmentDrushCommand extends PlatformCommand
         }
 
         $selectedEnvironment = $this->getSelectedEnvironment();
+
+        $this->waitUntilEnvironmentActive($selectedEnvironment, $this->getSelectedProject(), $input);
+
         $sshUrl = $selectedEnvironment->getSshUrl($input->getOption('app'));
 
         // The PLATFORM_DOCUMENT_ROOT environment variable is new. Default to

--- a/src/Command/EnvironmentRelationshipsCommand.php
+++ b/src/Command/EnvironmentRelationshipsCommand.php
@@ -5,6 +5,7 @@ namespace Platformsh\Cli\Command;
 use Platformsh\Cli\Util\RelationshipsUtil;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentRelationshipsCommand extends PlatformCommand
@@ -18,7 +19,8 @@ class EnvironmentRelationshipsCommand extends PlatformCommand
           ->setName('environment:relationships')
           ->setAliases(array('relationships'))
           ->setDescription('List an environment\'s relationships')
-          ->addArgument('environment', InputArgument::OPTIONAL, 'The environment');
+          ->addArgument('environment', InputArgument::OPTIONAL, 'The environment')
+          ->addOption('no-wait', null, InputOption::VALUE_NONE, "Do not wait for the environment to become active first");
         $this->addProjectOption()
              ->addEnvironmentOption()
              ->addAppOption();
@@ -28,8 +30,11 @@ class EnvironmentRelationshipsCommand extends PlatformCommand
     {
         $this->validateInput($input);
 
-        $sshUrl = $this->getSelectedEnvironment()
-          ->getSshUrl($input->getOption('app'));
+        $selectedEnvironment = $this->getSelectedEnvironment();
+
+        $this->waitUntilEnvironmentActive($selectedEnvironment, $this->getSelectedProject(), $input);
+
+        $sshUrl = $selectedEnvironment->getSshUrl($input->getOption('app'));
 
         $util = new RelationshipsUtil($this->stdErr);
         $relationships = $util->getRelationships($sshUrl);

--- a/src/Command/EnvironmentSqlCommand.php
+++ b/src/Command/EnvironmentSqlCommand.php
@@ -5,6 +5,7 @@ namespace Platformsh\Cli\Command;
 use Platformsh\Cli\Util\RelationshipsUtil;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentSqlCommand extends PlatformCommand
@@ -16,7 +17,8 @@ class EnvironmentSqlCommand extends PlatformCommand
             ->setName('environment:sql')
             ->setAliases(array('sql'))
             ->setDescription('Run SQL on the remote database')
-            ->addArgument('query', InputArgument::OPTIONAL, 'An SQL statement to execute');
+            ->addArgument('query', InputArgument::OPTIONAL, 'An SQL statement to execute')
+            ->addOption('no-wait', null, InputOption::VALUE_NONE, "Do not wait for the environment to become active first");
         $this->addProjectOption()->addEnvironmentOption()->addAppOption();
         $this->addExample('Open an SQL console on the remote database');
         $this->addExample('View tables on the remote database', "'SHOW TABLES'");
@@ -28,8 +30,11 @@ class EnvironmentSqlCommand extends PlatformCommand
 
         $sshOptions = '';
 
-        $sshUrl = $this->getSelectedEnvironment()
-          ->getSshUrl($input->getOption('app'));
+        $selectedEnvironment = $this->getSelectedEnvironment();
+
+        $this->waitUntilEnvironmentActive($selectedEnvironment, $this->getSelectedProject(), $input);
+
+        $sshUrl = $selectedEnvironment->getSshUrl($input->getOption('app'));
 
         $util = new RelationshipsUtil($this->stdErr);
         $database = $util->chooseDatabase($sshUrl, $input);

--- a/src/Command/EnvironmentSqlDumpCommand.php
+++ b/src/Command/EnvironmentSqlDumpCommand.php
@@ -17,7 +17,8 @@ class EnvironmentSqlDumpCommand extends PlatformCommand
             ->setName('environment:sql-dump')
             ->setAliases(array('sql-dump'))
             ->setDescription('Create a local dump of the remote database')
-            ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'A filename where the dump should be saved. Defaults to "dump.sql" in the project root');
+            ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'A filename where the dump should be saved. Defaults to "dump.sql" in the project root')
+            ->addOption('no-wait', null, InputOption::VALUE_NONE, "Do not wait for the environment to become active first");
         $this->addProjectOption()->addEnvironmentOption()->addAppOption();
     }
 
@@ -53,8 +54,11 @@ class EnvironmentSqlDumpCommand extends PlatformCommand
 
         $this->stdErr->writeln("Creating SQL dump file: <info>$dumpFile</info>");
 
-        $sshUrl = $this->getSelectedEnvironment()
-                       ->getSshUrl($input->getOption('app'));
+        $selectedEnvironment = $this->getSelectedEnvironment();
+
+        $this->waitUntilEnvironmentActive($selectedEnvironment, $this->getSelectedProject(), $input);
+
+        $sshUrl = $selectedEnvironment->getSshUrl($input->getOption('app'));
 
         $util = new RelationshipsUtil($this->stdErr);
         $database = $util->chooseDatabase($sshUrl, $input);

--- a/src/Command/EnvironmentSshCommand.php
+++ b/src/Command/EnvironmentSshCommand.php
@@ -19,8 +19,9 @@ class EnvironmentSshCommand extends PlatformCommand
         $this
           ->setName('environment:ssh')
           ->setAliases(array('ssh'))
-          ->addArgument('cmd', InputArgument::OPTIONAL, 'A command to run on the environment.')
-          ->addOption('pipe', null, InputOption::VALUE_NONE, "Output the SSH URL only.")
+          ->addArgument('cmd', InputArgument::OPTIONAL, 'A command to run on the environment')
+          ->addOption('pipe', null, InputOption::VALUE_NONE, "Output the SSH URL only")
+          ->addOption('no-wait', null, InputOption::VALUE_NONE, "Do not wait for the environment to become active first")
           ->setDescription('SSH to the current environment');
         $this->addProjectOption()
              ->addEnvironmentOption()
@@ -34,8 +35,11 @@ class EnvironmentSshCommand extends PlatformCommand
     {
         $this->validateInput($input);
 
-        $sshUrl = $this->getSelectedEnvironment()
-                       ->getSshUrl($input->getOption('app'));
+        $environment = $this->getSelectedEnvironment();
+
+        $this->waitUntilEnvironmentActive($environment, $this->getSelectedProject(), $input);
+
+        $sshUrl = $environment->getSshUrl($input->getOption('app'));
 
         if ($input->getOption('pipe') || !$this->isTerminal($output)) {
             $output->write($sshUrl);

--- a/src/Command/EnvironmentUrlCommand.php
+++ b/src/Command/EnvironmentUrlCommand.php
@@ -4,6 +4,7 @@ namespace Platformsh\Cli\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentUrlCommand extends UrlCommandBase
@@ -20,7 +21,8 @@ class EnvironmentUrlCommand extends UrlCommandBase
             'path',
             InputArgument::OPTIONAL,
             'A path to append to the URL.'
-          );
+          )
+          ->addOption('no-wait', null, InputOption::VALUE_NONE, "Do not wait for the environment to become active first");
         $this->addProjectOption()
              ->addEnvironmentOption();
     }
@@ -31,8 +33,11 @@ class EnvironmentUrlCommand extends UrlCommandBase
 
         $selectedEnvironment = $this->getSelectedEnvironment();
 
+        $this->waitUntilEnvironmentActive($selectedEnvironment, $this->getSelectedProject(), $input);
+
         if (!$selectedEnvironment->hasLink('public-url')) {
-            throw new \Exception('No URL available');
+            $this->stdErr->writeln('No URL available. The environment may be inactive.');
+            return 1;
         }
 
         $url = $selectedEnvironment->getLink('public-url', true);
@@ -43,5 +48,6 @@ class EnvironmentUrlCommand extends UrlCommandBase
         }
 
         $this->openUrl($url, $input, $output);
+        return 0;
     }
 }


### PR DESCRIPTION
Ensures that these commands will succeed to find a remote SSH / public URL, if they ever can:

* `platform drush`
* `platform ssh`
* `platform relationships`
* `platform sql`
* `platform sql-dump`
* `platform url`

Might need to be broader in scope