### PR TITLE
Improve 'platform get' UX

### DIFF
--- a/src/Command/EnvironmentBranchCommand.php
+++ b/src/Command/EnvironmentBranchCommand.php
@@ -8,7 +8,6 @@ use Platformsh\Cli\Local\LocalBuild;
 use Platformsh\Cli\Local\LocalProject;
 use Platformsh\Cli\Util\ActivityUtil;
 use Platformsh\Client\Model\Environment;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -61,14 +60,10 @@ class EnvironmentBranchCommand extends PlatformCommand
         if (empty($branchName)) {
             if ($input->isInteractive()) {
                 // List environments.
-                $params = array(
-                  'command' => 'environments',
-                  '--project' => $this->getSelectedProject()['id'],
+                return $this->runOtherCommand(
+                  'environments',
+                  array('--project' => $this->getSelectedProject()->id)
                 );
-
-                return $this->getApplication()
-                            ->find('environments')
-                            ->run(new ArrayInput($params), $output);
             }
             $this->stdErr->writeln("<error>You must specify the name of the new branch.</error>");
 
@@ -92,16 +87,10 @@ class EnvironmentBranchCommand extends PlatformCommand
                                $this->stdErr
                              );
             if ($checkout) {
-                $checkoutCommand = $this->getApplication()
-                                        ->find('environment:checkout');
-                $checkoutInput = new ArrayInput(
-                  array(
-                    'command' => 'environment:checkout',
-                    'id' => $environment['id'],
-                  )
+                return $this->runOtherCommand(
+                  'environment:checkout',
+                  array('id' => $environment->id)
                 );
-
-                return $checkoutCommand->run($checkoutInput, $output);
             }
 
             return 1;

--- a/src/Command/LocalDrushAliasesCommand.php
+++ b/src/Command/LocalDrushAliasesCommand.php
@@ -67,7 +67,7 @@ class LocalDrushAliasesCommand extends PlatformCommand
         $drushHelper->ensureInstalled();
         $drushHelper->setHomeDir($homeDir);
 
-        if ($new_group && $new_group != $current_group) {
+        if ($new_group && ($new_group != $current_group || !$drushHelper->getAliases($current_group))) {
             $questionHelper = $this->getHelper('question');
             $existing = $drushHelper->getAliases($new_group);
             if ($existing) {

--- a/src/Command/ProjectGetCommand.php
+++ b/src/Command/ProjectGetCommand.php
@@ -47,12 +47,6 @@ class ProjectGetCommand extends PlatformCommand
             "Do not build the retrieved project"
           )
           ->addOption(
-            'include-inactive',
-            null,
-            InputOption::VALUE_NONE,
-            "List inactive environments too"
-          )
-          ->addOption(
             'host',
             null,
             InputOption::VALUE_OPTIONAL,
@@ -230,13 +224,12 @@ class ProjectGetCommand extends PlatformCommand
      */
     protected function offerEnvironmentChoice(array $environments, InputInterface $input)
     {
-        $includeInactive = $input->hasOption('include-inactive') && $input->getOption('include-inactive');
         // Create a list starting with "master".
         $default = 'master';
         $environmentList = array($default => $environments[$default]['title']);
         foreach ($environments as $environment) {
             $id = $environment->id;
-            if ($id != $default && (!$environment->operationAvailable('activate') || $includeInactive)) {
+            if ($id != $default) {
                 $environmentList[$id] = $environment['title'];
             }
         }

--- a/src/Command/ProjectGetCommand.php
+++ b/src/Command/ProjectGetCommand.php
@@ -2,10 +2,12 @@
 
 namespace Platformsh\Cli\Command;
 
+use Cocur\Slugify\Slugify;
 use Platformsh\Cli\Helper\GitHelper;
 use Platformsh\Cli\Helper\ShellHelper;
 use Platformsh\Cli\Local\LocalBuild;
 use Platformsh\Cli\Local\LocalProject;
+use Platformsh\Cli\Local\Toolstack\Drupal;
 use Platformsh\Client\Model\Environment;
 use Platformsh\Client\Model\Project;
 use Symfony\Component\Console\Input\InputArgument;
@@ -30,7 +32,7 @@ class ProjectGetCommand extends PlatformCommand
           ->addArgument(
             'directory-name',
             InputArgument::OPTIONAL,
-            'The directory name. Defaults to the project ID'
+            'The directory name. Defaults to the project title'
           )
           ->addOption(
             'environment',
@@ -78,15 +80,14 @@ class ProjectGetCommand extends PlatformCommand
             return 1;
         }
 
+        /** @var \Platformsh\Cli\Helper\PlatformQuestionHelper $questionHelper */
+        $questionHelper = $this->getHelper('question');
+
         $directoryName = $input->getArgument('directory-name');
         if (empty($directoryName)) {
-            $directoryName = $projectId;
-        }
-
-        if (file_exists($directoryName)) {
-            $this->stdErr->writeln("<error>The project directory '$directoryName' already exists.</error>");
-
-            return 1;
+            $slugify = new Slugify();
+            $directoryName = $project->title ? $slugify->slugify($project->title) : $project->id;
+            $directoryName = $questionHelper->askInput('Directory name', $input, $this->stdErr, $directoryName);
         }
 
         if ($projectRoot = $this->getProjectRoot()) {
@@ -97,14 +98,33 @@ class ProjectGetCommand extends PlatformCommand
             }
         }
 
+        /** @var \Platformsh\Cli\Helper\FilesystemHelper $fsHelper */
+        $fsHelper = $this->getHelper('fs');
+
         // Create the directory structure.
+        $existed = false;
+        if (file_exists($directoryName)) {
+            $existed = true;
+            $this->stdErr->writeln("The directory <error>$directoryName</error> already exists");
+            if ($questionHelper->confirm("Overwrite?", $input, $this->stdErr, false)) {
+                $fsHelper->remove($directoryName);
+            }
+            else {
+                return 1;
+            }
+        }
         mkdir($directoryName);
         $projectRoot = realpath($directoryName);
         if (!$projectRoot) {
             throw new \Exception("Failed to create project directory: $directoryName");
         }
 
-        $this->stdErr->writeln("Created project directory: $directoryName");
+        if ($existed) {
+            $this->stdErr->writeln("Re-created project directory: <info>$directoryName</info>");
+        }
+        else {
+            $this->stdErr->writeln("Created new project directory: <info>$directoryName</info>");
+        }
 
         $local = new LocalProject();
         $hostname = parse_url($project->getUri(), PHP_URL_HOST) ?: null;
@@ -115,7 +135,7 @@ class ProjectGetCommand extends PlatformCommand
         $environmentOption = $input->getOption('environment');
         if ($environmentOption) {
             if (!isset($environments[$environmentOption])) {
-                $this->stdErr->writeln("<error>Environment not found: $environmentOption</error>");
+                $this->stdErr->writeln("Environment not found: <error>$environmentOption</error>");
 
                 return 1;
             }
@@ -127,9 +147,6 @@ class ProjectGetCommand extends PlatformCommand
         } else {
             $environment = 'master';
         }
-
-        /** @var \Platformsh\Cli\Helper\FilesystemHelper $fsHelper */
-        $fsHelper = $this->getHelper('fs');
 
         // Prepare to talk to the Platform.sh repository.
         $gitUrl = $project->getGitUrl();
@@ -179,10 +196,12 @@ class ProjectGetCommand extends PlatformCommand
 
         $local->ensureGitRemote($repositoryDir, $gitUrl);
         $this->stdErr->writeln("The project <info>{$project->title}</info> was successfully downloaded to: <info>$directoryName</info>");
+        $this->setProjectRoot($projectRoot);
 
         // Ensure that Drush aliases are created.
-        $this->setProjectRoot($projectRoot);
-        $this->updateDrushAliases($project, $environments);
+        if (Drupal::isDrupal($projectRoot . '/' . LocalProject::REPOSITORY_DIR)) {
+            $this->runOtherCommand('local:drush-aliases', array('--group' => $directoryName), $input);
+        }
 
         // Allow the build to be skipped.
         if ($input->getOption('no-build')) {

--- a/src/Command/WelcomeCommand.php
+++ b/src/Command/WelcomeCommand.php
@@ -2,7 +2,6 @@
 
 namespace Platformsh\Cli\Command;
 
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,26 +39,12 @@ class WelcomeCommand extends PlatformCommand
             $this->stdErr->writeln("Project Name: <info>$projectName</info>");
             $this->stdErr->writeln("Project ID: <info>$projectId</info>");
             $this->stdErr->writeln("Project Dashboard: <info>$projectURI</info>\n");
-            $envInput = new ArrayInput(
-              array(
-                'command' => 'environments',
-                '--refresh' => 0,
-              )
-            );
-            $application->find('environments')
-                        ->run($envInput, $output);
+            $this->runOtherCommand('environments', array('--refresh' => 0));
             $this->stdErr->writeln("\nYou can list other projects by running <info>platform projects</info>\n");
             $this->stdErr->writeln("Manage your domains by running <info>platform domains</info>");
         } else {
             // The project is not known. Show all projects.
-            $projectsInput = new ArrayInput(
-              array(
-                'command' => 'projects',
-                '--refresh' => 0,
-              )
-            );
-            $application->find('projects')
-                        ->run($projectsInput, $output);
+            $this->runOtherCommand('projects', array('--refresh' => 0));
         }
 
         $this->stdErr->writeln("Manage your SSH keys by running <info>platform ssh-keys</info>\n");

--- a/src/Local/LocalProject.php
+++ b/src/Local/LocalProject.php
@@ -35,7 +35,7 @@ class LocalProject
             $projectConfig['host'] = $host;
         }
         $dumper = new Dumper();
-        file_put_contents($projectRoot . '/' . self::PROJECT_CONFIG, $dumper->dump($projectConfig));
+        file_put_contents($projectRoot . '/' . self::PROJECT_CONFIG, $dumper->dump($projectConfig, 2));
     }
 
     /**
@@ -262,7 +262,7 @@ class LocalProject
         }
         $dumper = new Dumper();
         $projectConfig[$key] = $value;
-        file_put_contents($file, $dumper->dump($projectConfig));
+        file_put_contents($file, $dumper->dump($projectConfig, 2));
 
         return $projectConfig;
     }


### PR DESCRIPTION
* Default project directory will be a slug of the project title, instead of the ID.
* Default Drush alias group will be the same as the directory name.
* The created aliases are shown in the output of `get`.
* You can use `get` when the specified directory already exists (you will be asked if you want to overwrite it).
* Removed unnecessary `--include-inactive` option.