### PR TITLE
Improve progress bars for activities

### DIFF
--- a/src/Command/Activity/ActivityListCommand.php
+++ b/src/Command/Activity/ActivityListCommand.php
@@ -2,6 +2,7 @@
 namespace Platformsh\Cli\Command\Activity;
 
 use Platformsh\Cli\Command\PlatformCommand;
+use Platformsh\Cli\Util\ActivityUtil;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -50,7 +51,7 @@ class ActivityListCommand extends PlatformCommand
             return 1;
         }
 
-        $headers = array("ID", "Created", "Description", "% Complete", "Result");
+        $headers = array("ID", "Created", "Description", "% Complete", "State");
         $rows = array();
         foreach ($activities as $activity) {
             $description = $activity->getDescription();
@@ -60,7 +61,7 @@ class ActivityListCommand extends PlatformCommand
               date('Y-m-d H:i:s', strtotime($activity['created_at'])),
               $description,
               $activity->getCompletionPercent(),
-              $activity->state,
+              ActivityUtil::formatState($activity->state),
             );
         }
 

--- a/src/Command/Activity/ActivityLogCommand.php
+++ b/src/Command/Activity/ActivityLogCommand.php
@@ -58,7 +58,7 @@ class ActivityLogCommand extends PlatformCommand
         }
 
         $this->stdErr->writeln(
-          "Log for activity <info>" . $activity['id'] . "</info> (" . $activity->getDescription() . "):"
+          "Log for activity <info>" . $activity['id'] . "</info> (" . $activity->getDescription() . "):\n"
         );
 
         $refresh = $input->getOption('refresh');
@@ -77,7 +77,7 @@ class ActivityLogCommand extends PlatformCommand
     protected function displayLog(Activity $activity, OutputInterface $output, $poll = true, $interval = 1)
     {
         $logger = function ($log) use ($output) {
-            $output->write(preg_replace('/^/m', '    ', $log));
+            $output->write($log);
         };
         if (!$poll) {
             $logger($activity['log']);

--- a/src/Command/Environment/EnvironmentActivateCommand.php
+++ b/src/Command/Environment/EnvironmentActivateCommand.php
@@ -88,14 +88,16 @@ class EnvironmentActivateCommand extends PlatformCommand
                 $output->writeln($e->getMessage());
             }
         }
+
+        $success = true;
         if ($processed) {
             if (!$input->getOption('no-wait')) {
-                ActivityUtil::waitMultiple($activities, $output);
+                $success = ActivityUtil::waitMultiple($activities, $output);
             }
             $this->clearEnvironmentsCache();
         }
 
-        return $processed >= $count;
+        return $processed >= $count && $success;
     }
 
 }

--- a/src/Command/Environment/EnvironmentBranchCommand.php
+++ b/src/Command/Environment/EnvironmentBranchCommand.php
@@ -169,9 +169,6 @@ class EnvironmentBranchCommand extends PlatformCommand
               "The environment <info>$branchName</info> has been branched.",
               '<error>Branching failed</error>'
             );
-
-            // Clear the environments cache again.
-            $this->clearEnvironmentsCache($selectedProject);
         }
 
         $build = $input->getOption('build');

--- a/src/Command/Environment/EnvironmentDeleteCommand.php
+++ b/src/Command/Environment/EnvironmentDeleteCommand.php
@@ -181,7 +181,9 @@ class EnvironmentDeleteCommand extends PlatformCommand
         }
 
         if (!$input->getOption('no-wait')) {
-            ActivityUtil::waitMultiple($deactivateActivities, $output);
+            if (!ActivityUtil::waitMultiple($deactivateActivities, $output)) {
+                $error = true;
+            }
         }
 
         $deleted = 0;

--- a/src/Command/Environment/EnvironmentHttpAccessCommand.php
+++ b/src/Command/Environment/EnvironmentHttpAccessCommand.php
@@ -190,6 +190,7 @@ class EnvironmentHttpAccessCommand extends PlatformCommand
 
                 // Patch the environment with the changes.
                 $activity = $selectedEnvironment->update(array('http_access' => $accessOpts));
+                $this->clearEnvironmentsCache();
 
                 $this->stdErr->writeln("Updated HTTP access settings for the environment <info>$environmentId</info>:");
 

--- a/src/Command/Environment/EnvironmentInfoCommand.php
+++ b/src/Command/Environment/EnvironmentInfoCommand.php
@@ -115,6 +115,8 @@ class EnvironmentInfoCommand extends PlatformCommand
         $activity = $environment->update(array($property => $value));
         $this->stdErr->writeln("Property <info>$property</info> set to: " . $this->formatter->format($environment[$property], $property));
 
+        $this->clearEnvironmentsCache();
+
         $rebuildProperties = array('enable_smtp', 'restrict_robots');
         $success = true;
         if ($activity instanceof Activity && !$noWait) {
@@ -123,8 +125,6 @@ class EnvironmentInfoCommand extends PlatformCommand
         elseif (!($activity instanceof Activity) && in_array($property, $rebuildProperties)) {
             $this->rebuildWarning();
         }
-
-        $this->clearEnvironmentsCache();
 
         return $success ? 0 : 1;
     }

--- a/src/Command/Environment/EnvironmentMergeCommand.php
+++ b/src/Command/Environment/EnvironmentMergeCommand.php
@@ -50,6 +50,8 @@ class EnvironmentMergeCommand extends PlatformCommand
 
         $this->stdErr->writeln("Merging <info>$environmentId</info> with <info>$parentId</info>");
 
+        $this->clearEnvironmentsCache();
+
         $activity = $selectedEnvironment->merge();
         if (!$input->getOption('no-wait')) {
             $this->stdErr->writeln("Waiting for the merge to complete...");
@@ -63,8 +65,6 @@ class EnvironmentMergeCommand extends PlatformCommand
                 return 1;
             }
         }
-
-        $this->clearEnvironmentsCache();
 
         return 0;
     }

--- a/src/Command/User/UserAddCommand.php
+++ b/src/Command/User/UserAddCommand.php
@@ -115,8 +115,8 @@ class UserAddCommand extends PlatformCommand
 
         $this->stdErr->writeln("User <info>$email</info> created");
 
+        $success = true;
         if (!empty($environmentRoles)) {
-
             if (!isset($result['_embedded']['entity']['id'])) {
                 $this->stdErr->writeln("Failed to find user ID from response");
                 return 1;
@@ -128,6 +128,7 @@ class UserAddCommand extends PlatformCommand
             foreach ($environmentRoles as $environmentId => $role) {
                 if (!isset($environments[$environmentId])) {
                     $this->stdErr->writeln("<error>Environment not found: $environmentId</error>");
+                    $success = false;
                     continue;
                 }
                 if ($role == 'none') {
@@ -144,11 +145,13 @@ class UserAddCommand extends PlatformCommand
                 }
             }
             if (!$input->getOption('no-wait')) {
-                ActivityUtil::waitMultiple($activities, $this->stdErr);
+                if (!ActivityUtil::waitMultiple($activities, $this->stdErr)) {
+                    $success = false;
+                }
             }
         }
 
-        return 0;
+        return $success ? 0 : 1;
     }
 
     /**

--- a/src/Util/ActivityUtil.php
+++ b/src/Util/ActivityUtil.php
@@ -9,6 +9,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class ActivityUtil
 {
 
+    protected static $stateNames = [
+        Activity::STATE_PENDING => 'pending',
+        Activity::STATE_COMPLETE => 'complete',
+        Activity::STATE_IN_PROGRESS => 'in progress',
+    ];
+
     /**
      * Wait for a single activity to complete, and display the log.
      *
@@ -22,13 +28,31 @@ abstract class ActivityUtil
      */
     public static function waitAndLog(Activity $activity, OutputInterface $output, $success = null, $failure = null)
     {
-        $output->writeln('Waiting for the activity <info>' . $activity->id . '</info> (' . $activity->getDescription() . '):');
+        $output->writeln('Waiting for the activity <info>' . $activity->id . '</info> (' . $activity->getDescription() . "):");
+        $bar = new ProgressBar($output);
+        $bar->setPlaceholderFormatterDefinition('state', function () use ($activity) {
+            return self::formatState($activity->state);
+        });
+        $bar->setFormat("  [%bar%] %elapsed:6s% (%state%)");
+        $bar->start();
         $activity->wait(
-          null,
-          function ($log) use ($output) {
+          function () use ($bar) {
+              $bar->advance();
+          },
+          function ($log) use ($output, $bar) {
+              // Clear the progress bar and ensure the current line is flushed.
+              $bar->clear();
+              $output->write($output->isDecorated() ? "\n\033[1A" : "\n");
+
+              // Display the new log output, with an indent.
               $output->write(preg_replace('/^/m', '    ', $log));
+
+              // Display the progress bar again.
+              $bar->advance();
           }
         );
+        $bar->finish();
+        $output->writeln('');
         switch ($activity['result']) {
             case 'success':
                 if ($success !== null) {
@@ -50,12 +74,15 @@ abstract class ActivityUtil
      * @param Activity[]      $activities
      * @param OutputInterface $output
      * @param string|null $message
+     *
+     * @return bool
+     *   True if all activities succeed, false otherwise.
      */
     public static function waitMultiple(array $activities, OutputInterface $output, $message = null)
     {
         $count = count($activities);
-        if ($count <= 0) {
-            return;
+        if ($count == 0) {
+            return true;
         }
         $complete = 0;
         if ($message === null) {
@@ -64,21 +91,65 @@ abstract class ActivityUtil
         }
         $output->writeln($message);
         $bar = new ProgressBar($output);
-        $bar->start($count);
-        $bar->setFormat('verbose');
+        $states = [];
+        foreach ($activities as $activity) {
+            $state = $activity->state;
+            $states[$state] = isset($states[$state]) ? $states[$state] + 1 : 1;
+        }
+        $bar->setPlaceholderFormatterDefinition('states', function () use (&$states) {
+            $format = '';
+            foreach ($states as $state => $count) {
+                $format .= $count . ' ' . self::formatState($state) . ', ';
+            }
+
+            return rtrim($format, ', ');
+        });
+        $bar->setFormat("  [%bar%] %elapsed:6s% (%states%)");
+        $bar->start();
         while ($complete < $count) {
             sleep(1);
+            $states = [];
             foreach ($activities as $activity) {
                 if (!$activity->isComplete()) {
                     $activity->refresh();
                 } else {
                     $complete++;
                 }
+                $state = $activity->state;
+                $states[$state] = isset($states[$state]) ? $states[$state] + 1 : 1;
             }
-            $bar->setProgress($complete);
+            $bar->advance();
         }
         $bar->finish();
         $output->writeln('');
+
+        $success = true;
+        foreach ($activities as $activity) {
+            // Display a message for successful activities.
+            if ($activity->result === Activity::RESULT_SUCCESS) {
+                $output->writeln("Activity <info>{$activity->id}</info> (" . $activity->getDescription() . ") succeeded");
+            }
+            // Display the activity log if there was a failure.
+            elseif ($activity->result === Activity::RESULT_FAILURE) {
+                $success = false;
+                $output->writeln("Activity <error>{$activity->id}</error> (" . $activity->getDescription() . ") failed");
+                $output->writeln("Log:");
+                $output->writeln(preg_replace('/^/m', '    ', $activity->log));
+            }
+        }
+
+        return $success;
     }
 
+    /**
+     * Format a state name.
+     *
+     * @param string $state
+     *
+     * @return string
+     */
+    public static function formatState($state)
+    {
+        return isset(self::$stateNames[$state]) ? self::$stateNames[$state] : $state;
+    }
 }


### PR DESCRIPTION
* show a progress bar alongside the activity log, so user has feedback that polling is happening
* show activity state(s) in the progress bar, so the user understands what's pending
* advance the progress bar on every poll, not just when something changes (look lively)