### PR TITLE
Allow non-interactive choice about deleting branches

### DIFF
--- a/src/Command/Environment/EnvironmentDeleteCommand.php
+++ b/src/Command/Environment/EnvironmentDeleteCommand.php
@@ -20,6 +20,7 @@ class EnvironmentDeleteCommand extends PlatformCommand
           ->setName('environment:delete')
           ->setDescription('Delete an environment')
           ->addArgument('environment', InputArgument::IS_ARRAY, 'The environment(s) to delete')
+          ->addOption('delete-branch', null, InputOption::VALUE_NONE, 'Delete the remote Git branch(es) too')
           ->addOption('inactive', null, InputOption::VALUE_NONE, 'Delete all inactive environments')
           ->addOption('merged', null, InputOption::VALUE_NONE, 'Delete all merged environments');
         $this->addProjectOption()
@@ -148,8 +149,7 @@ class EnvironmentDeleteCommand extends PlatformCommand
                 $question = "Are you sure you want to delete the environment <comment>$environmentId</comment>?";
                 if ($questionHelper->confirm($question, $input, $output)) {
                     $deactivate[$environmentId] = $environment;
-                    $question = "Delete the remote Git branch too?";
-                    if ($questionHelper->confirm($question, $input, $output)) {
+                    if ($input->getOption('delete-branch') || ($input->isInteractive() && $questionHelper->confirm("Delete the remote Git branch too?", $input, $output))) {
                         $delete[$environmentId] = $environment;
                     }
                 }


### PR DESCRIPTION
Addresses issue #357.

Previously the remote Git branch would always be deleted if `--yes` was used
with the `environment:delete` command. Now it will only be deleted if the
option `--delete-branch` is appended.