### PR TITLE
Speed up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ php:
   - hhvm
   - 7.0
 
-matrix:
-  allow_failures:
-    - php: 7.0
-  fast_finish: true
-
 cache:
   directories:
     - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,13 @@ matrix:
     - php: 7.0
   fast_finish: true
 
-env:
-  - COMPOSER_LOWEST=0
-  - COMPOSER_LOWEST=1
-
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.drush/cache
 
 install:
   - composer install --no-interaction
-  - if [ "$COMPOSER_LOWEST" = 1 ]; then travis_wait composer update --prefer-lowest --no-interaction; fi
 
 script:
   - ./vendor/bin/phpunit -c ./phpunit.xml --coverage-text


### PR DESCRIPTION
Now the recommended install method is the Phar, there is no need to test with the lowest Composer dependencies