### PR TITLE
Install build-time dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ install:
 
 script:
   - ./vendor/bin/security-checker security:check --no-interaction ./composer.lock
-  - ./vendor/bin/phpunit -c ./phpunit.xml --coverage-text
+  - ./vendor/bin/phpunit -c ./phpunit.xml --coverage-text --exclude-group slow

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,7 @@ local:
   local_dir: '.platform/local'
   archive_dir: '.platform/local/build-archives'
   build_dir: '.platform/local/builds'
+  dependencies_dir: '.platform/local/deps'
   project_config: '.platform/local/project.yaml'
   project_config_legacy: '.platform-project'
   shared_dir: '.platform/local/shared'

--- a/services.yaml
+++ b/services.yaml
@@ -24,7 +24,10 @@ services:
         arguments: ['@shell']
     local.build:
         class:     '\Platformsh\Cli\Local\LocalBuild'
-        arguments: ['@config', '@output', '@shell', '@fs', '@git']
+        arguments: ['@config', '@output', '@shell', '@fs', '@git', '@local.dependency_installer']
+    local.dependency_installer:
+        class:     '\Platformsh\Cli\Local\DependencyInstaller'
+        arguments: ['@output', '@shell']
     local.project:
         class:     '\Platformsh\Cli\Local\LocalProject'
         arguments: ['@config', '@git']

--- a/src/Command/Local/LocalBuildCommand.php
+++ b/src/Command/Local/LocalBuildCommand.php
@@ -87,6 +87,12 @@ class LocalBuildCommand extends CommandBase
                 'Do not run post-build hooks'
             )
             ->addOption(
+                'no-deps',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not install build dependencies locally'
+            )
+            ->addOption(
                 'working-copy',
                 null,
                 InputOption::VALUE_NONE,

--- a/src/Local/DependencyInstaller.php
+++ b/src/Local/DependencyInstaller.php
@@ -1,0 +1,105 @@
+<?php
+namespace Platformsh\Cli\Local;
+
+use Platformsh\Cli\Service\Shell;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DependencyInstaller
+{
+    protected $output;
+    protected $shell;
+
+    public function __construct(OutputInterface $output, Shell $shell)
+    {
+        $this->output = $output;
+        $this->shell = $shell;
+    }
+
+    /**
+     * Modify the environment to make the installed dependencies available.
+     *
+     * @param string $destination
+     * @param array  $dependencies
+     */
+    public function putEnv($destination, array $dependencies)
+    {
+        $env = [];
+        $paths = [];
+        foreach ($dependencies as $stack => $stackDependencies) {
+            $manager = $this->getManager($stack);
+            $path = $destination . '/' . $stack;
+            $paths = array_merge($paths, $manager->getBinPaths($path));
+            $env = array_merge($env, $manager->getEnvVars($path));
+        }
+        $paths = array_filter(array_map('realpath', $paths));
+        if (!empty($paths)) {
+            $pathVariable = stripos(PHP_OS, 'WIN') === 0 ? 'Path' : 'PATH';
+            $env[$pathVariable] = implode(':', $paths);
+            if (getenv($pathVariable)) {
+                $env[$pathVariable] .= ':' . getenv($pathVariable);
+            }
+        }
+        foreach ($env as $name => $value) {
+            putenv($name . '=' . $value);
+        }
+    }
+
+    /**
+     * @param string $destination
+     * @param array $dependencies
+     */
+    public function installDependencies($destination, array $dependencies)
+    {
+        foreach ($dependencies as $stack => $stackDependencies) {
+            $manager = $this->getManager($stack);
+            $this->output->writeln(sprintf(
+                "Installing <info>%s</info> dependencies with '%s': %s",
+                $stack,
+                $manager->getCommandName(),
+                implode(', ', array_keys($stackDependencies))
+            ));
+            if (!$manager->isAvailable()) {
+                throw new \RuntimeException(rtrim(sprintf(
+                    "Cannot install %s dependencies: '%s' is not installed\n%s",
+                    $stack,
+                    $manager->getCommandName(),
+                    $manager->getInstallHelp()
+                )));
+            }
+            $path = $destination . '/' . $stack;
+            $this->ensureDirectory($path);
+            $manager->install($path, $stackDependencies);
+        }
+    }
+
+    /**
+     * @param string $path
+     */
+    protected function ensureDirectory($path)
+    {
+        if (!is_dir($path) && !mkdir($path, 0755, true)) {
+            throw new \RuntimeException('Failed to create directory: ' . $path);
+        }
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Platformsh\Cli\Local\DependencyManager\DependencyManagerInterface
+     */
+    protected function getManager($name)
+    {
+        $stacks = [
+            'nodejs' => new DependencyManager\Yarn($this->shell),
+            'python' => new DependencyManager\Pip($this->shell),
+            'ruby' => new DependencyManager\Bundler($this->shell),
+            'php' => new DependencyManager\Composer($this->shell),
+        ];
+
+        if (!isset($stacks[$name])) {
+            throw new \InvalidArgumentException(sprintf('Unknown dependencies stack: %s', $name));
+        }
+
+        return $stacks[$name];
+    }
+}

--- a/src/Local/DependencyManager/Bundler.php
+++ b/src/Local/DependencyManager/Bundler.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Platformsh\Cli\Local\DependencyManager;
+
+class Bundler extends DependencyManagerBase
+{
+    protected $command = 'bundler';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInstallHelp()
+    {
+        return 'See http://bundler.io/ for installation instructions.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinPaths($prefix)
+    {
+        return [$prefix . '/bin'];
+    }
+
+    /**
+     * @param string $path
+     *
+     * @param array  $dependencies
+     */
+    public function install($path, array $dependencies)
+    {
+        $gemFile = $path . '/Gemfile';
+        $gemFileContent = $this->formatGemfile($dependencies);
+        $current = file_exists($gemFile) ? file_get_contents($gemFile) : false;
+        if ($current !== $gemFileContent) {
+            file_put_contents($gemFile, $gemFileContent);
+            if (file_exists($path . '/Gemfile.lock')) {
+                unlink('Gemfile.lock');
+            }
+        }
+        $this->runCommand('bundler install --path=. --binstubs', $path);
+    }
+
+    /**
+     * @param array $dependencies
+     *
+     * @return string
+     */
+    private function formatGemfile(array $dependencies)
+    {
+        $lines = ["source 'https://rubygems.org'"];
+        foreach ($dependencies as $package => $version) {
+            if ($version != '*') {
+                $lines[] = sprintf("gem '%s', '%s', :require => false", $package, $version);
+            } else {
+                $lines[] = sprintf("gem '%s', :require => false", $package);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/Local/DependencyManager/Composer.php
+++ b/src/Local/DependencyManager/Composer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Platformsh\Cli\Local\DependencyManager;
+
+class Composer extends DependencyManagerBase
+{
+    protected $command = 'composer';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInstallHelp()
+    {
+        return 'See https://getcomposer.org/ for installation instructions.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinPaths($prefix)
+    {
+        return [$prefix . '/vendor/bin'];
+    }
+
+    /**
+     * @param string $path
+     *
+     * @param array  $dependencies
+     */
+    public function install($path, array $dependencies)
+    {
+        $composerJson = $path . '/composer.json';
+        $contents = file_exists($composerJson) ? file_get_contents($composerJson) : null;
+        $newContents = json_encode(['require' => $dependencies]);
+        if ($contents !== $newContents) {
+            file_put_contents($composerJson, $newContents);
+            if (file_exists($path . '/composer.lock')) {
+                unlink($path . '/composer.lock');
+            }
+        }
+        $this->runCommand('composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction', $path);
+    }
+}

--- a/src/Local/DependencyManager/DependencyManagerBase.php
+++ b/src/Local/DependencyManager/DependencyManagerBase.php
@@ -1,0 +1,55 @@
+<?php
+namespace Platformsh\Cli\Local\DependencyManager;
+
+use Platformsh\Cli\Service\Shell;
+
+abstract class DependencyManagerBase implements DependencyManagerInterface
+{
+    protected $shell;
+    protected $command = 'undefined';
+
+    public function __construct(Shell $shell)
+    {
+        $this->shell = $shell;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCommandName()
+    {
+        return $this->command;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAvailable()
+    {
+        return $this->shell->commandExists($this->command);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnvVars($path)
+    {
+        return [];
+    }
+
+    /**
+     * @param string $command
+     * @param string $path
+     */
+    protected function runCommand($command, $path)
+    {
+        $code = $this->shell->executeSimple($command, $path);
+        if ($code > 0) {
+            throw new \RuntimeException(sprintf(
+                'The command failed with the exit code %d: %s',
+                $code,
+                $command
+            ));
+        }
+    }
+}

--- a/src/Local/DependencyManager/DependencyManagerInterface.php
+++ b/src/Local/DependencyManager/DependencyManagerInterface.php
@@ -1,0 +1,42 @@
+<?php
+namespace Platformsh\Cli\Local\DependencyManager;
+
+interface DependencyManagerInterface
+{
+    /**
+     * @return string
+     */
+    public function getCommandName();
+
+    /**
+     * @return bool
+     */
+    public function isAvailable();
+
+    /**
+     * @return string
+     */
+    public function getInstallHelp();
+
+    /**
+     * @param string $path The path prefix for the dependencies.
+     *
+     * @param array $dependencies An associative array of dependencies with
+     *                            their versions.
+     */
+    public function install($path, array $dependencies);
+
+    /**
+     * @param string $path The path prefix for the dependencies.
+     *
+     * @return array An array of absolute paths to "bin" directories.
+     */
+    public function getBinPaths($path);
+
+    /**
+     * @param string $path The path prefix for the dependencies.
+     *
+     * @return array An associative array of environment variables.
+     */
+    public function getEnvVars($path);
+}

--- a/src/Local/DependencyManager/Pip.php
+++ b/src/Local/DependencyManager/Pip.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Platformsh\Cli\Local\DependencyManager;
+
+class Pip extends DependencyManagerBase
+{
+    protected $command = 'pip';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInstallHelp()
+    {
+        return 'See https://pip.pypa.io/en/stable/installing/ for installation instructions.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinPaths($prefix)
+    {
+        return [$prefix . '/bin'];
+    }
+
+    /**
+     * @param string $path
+     *
+     * @param array  $dependencies
+     */
+    public function install($path, array $dependencies)
+    {
+        file_put_contents($path . '/requirements.txt', $this->formatRequirementsTxt($dependencies));
+        $this->runCommand('pip install --requirement=requirements.txt --prefix=.', $path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnvVars($path)
+    {
+        return ['PYTHONPATH' => $path];
+    }
+
+    /**
+     * @param array $dependencies
+     *
+     * @return string
+     */
+    private function formatRequirementsTxt(array $dependencies)
+    {
+        $lines = [];
+        foreach ($dependencies as $package => $version) {
+            if (in_array($version[0], ['<', '!', '>', '='])) {
+                $lines[] = sprintf('%s%s', $package, $version);
+            } elseif ($version === '*') {
+                $lines[] = $package;
+            } else {
+                $lines[] = sprintf('%s==%s', $package, $version);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/Local/DependencyManager/Yarn.php
+++ b/src/Local/DependencyManager/Yarn.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Platformsh\Cli\Local\DependencyManager;
+
+class Yarn extends DependencyManagerBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getInstallHelp()
+    {
+        return 'See https://yarnpkg.com/en/docs/install for installation instructions.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCommandName()
+    {
+        return $this->shell->commandExists('yarn') ? 'yarn' : 'npm';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAvailable()
+    {
+        return $this->shell->commandExists('yarn') || $this->shell->commandExists('npm');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinPaths($prefix)
+    {
+        return [$prefix . '/node_modules/.bin'];
+    }
+
+    /**
+     * @param string $path
+     *
+     * @param array  $dependencies
+     */
+    public function install($path, array $dependencies)
+    {
+        $packageJsonFile = $path . '/package.json';
+        $packageJson = json_encode([
+            'name' => 'temporary-build-dependencies',
+            'version' => '1.0.0',
+            'private' => true,
+            'dependencies' => $dependencies,
+        ], JSON_PRETTY_PRINT);
+        $current = file_exists($packageJsonFile) ? file_get_contents($packageJsonFile) : false;
+        if ($current !== $packageJson) {
+            file_put_contents($packageJsonFile, $packageJson);
+            if (file_exists($path . '/yarn.lock')) {
+                unlink($path . '/yarn.lock');
+            }
+        }
+        if ($this->shell->commandExists('yarn')) {
+            $this->runCommand('yarn install', $path);
+        } else {
+            $this->runCommand('npm install --global-style', $path);
+        }
+    }
+}

--- a/src/Service/Filesystem.php
+++ b/src/Service/Filesystem.php
@@ -450,6 +450,6 @@ class Filesystem
      */
     protected function isWindows()
     {
-        return strpos(PHP_OS, 'WIN') !== false;
+        return stripos(PHP_OS, 'WIN') === 0;
     }
 }

--- a/tests/Local/Toolstack/BaseToolstackTest.php
+++ b/tests/Local/Toolstack/BaseToolstackTest.php
@@ -48,18 +48,20 @@ abstract class BaseToolstackTest extends \PHPUnit_Framework_TestCase
      * @param string $sourceDir
      *   A directory containing source code for the project or app. Files will
      *   be copied into a dummy project.
-     * @param array $buildSettings
+     * @param array  $buildSettings
      *   An array of custom build settings.
+     * @param bool   $expectedResult
+     *   The expected build result.
      *
      * @return string
      *   The project root for the dummy project.
      */
-    protected function assertBuildSucceeds($sourceDir, array $buildSettings = [])
+    protected function assertBuildSucceeds($sourceDir, array $buildSettings = [], $expectedResult = true)
     {
         $projectRoot = $this->createDummyProject($sourceDir);
         self::$output->writeln("\nTesting build for directory: " . $sourceDir);
         $success = $this->builder->build($buildSettings + $this->buildSettings, $projectRoot);
-        $this->assertTrue($success, 'Build success for dir: ' . $sourceDir);
+        $this->assertSame($expectedResult, $success, 'Build for dir: ' . $sourceDir);
 
         return $projectRoot;
     }

--- a/tests/Local/Toolstack/DependenciesTest.php
+++ b/tests/Local/Toolstack/DependenciesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Platformsh\Cli\Tests\Toolstack;
+
+/**
+ * @group slow
+ */
+class DependenciesTest extends BaseToolstackTest
+{
+    protected $sourceDir = 'tests/data/apps/build-deps';
+
+    public function testBuildSucceedsIfDepsNotRequired()
+    {
+        $this->assertBuildSucceeds($this->sourceDir, ['no-deps' => true, 'no-build-hooks' => true]);
+    }
+
+    public function testBuildFailsIfDepsNotInstalled()
+    {
+        $this->assertBuildSucceeds($this->sourceDir, ['no-deps' => true], false);
+    }
+
+    public function testBuildSucceedsIfDepsInstalled()
+    {
+        $this->assertBuildSucceeds($this->sourceDir);
+    }
+}

--- a/tests/data/apps/build-deps/.platform.app.yaml
+++ b/tests/data/apps/build-deps/.platform.app.yaml
@@ -1,0 +1,21 @@
+name: build-deps
+type: nodejs
+build:
+  flavor: none
+dependencies:
+  nodejs:
+    less: '*'
+  python:
+    awscli: '*'
+  php:
+    platformsh/cli: '*'
+  ruby:
+    compass: '*'
+hooks:
+  # Test that the four CLI tools installed above are present.
+  build: |
+    set -xe
+    command -v lessc
+    command -v aws
+    command -v platform
+    command -v compass


### PR DESCRIPTION
Issue #379 

- [x] test composer support
- [x] test npm support
- [x] test pip support
- [x] test bundler support
- [x] check if `npm` doesn't exist (for example), and if not, give user recommendations for installing it
- [x] try to use `yarn` instead of `npm` if possible? and use the lock file if the package.json does not change
- [x] something similar with lock files for `bundler` and `pip`?