### PR TITLE
Ability to pass --quiet onto runOtherCommand().

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1242,7 +1242,18 @@ abstract class CommandBase extends Command implements CanHideInListInterface
 
         $this->debug('Running command: ' . $name);
 
-        return $command->run($cmdInput, $this->output);
+        // If -q|--quiet is in $arguments, then override IO configuration by
+        // temporarily suppressing the output for this command only.
+        if (!empty($arguments['-q']) || !empty($arguments['--quiet'])) {
+            $originalVerbosity = $this->output->getVerbosity();
+            $this->output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+            $cmdReturnStatus = $command->run($cmdInput, $this->output);
+            $this->output->setVerbosity($originalVerbosity);
+            return $cmdReturnStatus;
+        }
+        else {
+            return $command->run($cmdInput, $this->output);
+        }
     }
 
     /**


### PR DESCRIPTION
This is related to https://github.com/platformsh/platformsh-cli/issues/395.

Passing `--quiet` to `runOtherCommand()` won't have any effect because the `configureIO()` is invoked within `Symfony\Component\Console\Application::run()` before the `doRun()` method is invoked (which is the one that actually invokes the commands). So, if `platform` was executed without `--quiet`, that would stick throughout all the execution flow, even with the commands run by other commands using `runOtherCommand()`.

This is an attempt to provide a solution for this, if appropriate.