### PR TITLE
Add 'platform multi' command

### DIFF
--- a/resources/console/dialogrc
+++ b/resources/console/dialogrc
@@ -1,0 +1,3 @@
+use_shadow = OFF
+use_colors = ON
+screen_color = (WHITE,DEFAULT,OFF)

--- a/src/Api.php
+++ b/src/Api.php
@@ -391,10 +391,20 @@ class Api
     public static function sortResources(array &$resources, $propertyName)
     {
         uasort($resources, function (ApiResource $a, ApiResource $b) use ($propertyName) {
-            $valueA = $a->getProperty($propertyName);
-            $valueB = $b->getProperty($propertyName);
+            $valueA = $a->getProperty($propertyName, true, false);
+            $valueB = $b->getProperty($propertyName, true, false);
 
-            return gettype($valueA) === 'string' ? strcmp($valueA, $valueB) : $valueA - $valueB;
+            switch (gettype($valueA)) {
+                case 'string':
+                    return strcasecmp($valueA, $valueB);
+
+                case 'integer':
+                case 'double':
+                case 'boolean':
+                    return $valueA - $valueB;
+            }
+
+            return 0;
         });
 
         return $resources;

--- a/src/Application.php
+++ b/src/Application.php
@@ -104,6 +104,7 @@ class Application extends ParentApplication
         $commands[] = new Command\CompletionCommand();
         $commands[] = new Command\DocsCommand();
         $commands[] = new Command\LegacyMigrateCommand();
+        $commands[] = new Command\MultiCommand();
         $commands[] = new Command\Activity\ActivityListCommand();
         $commands[] = new Command\Activity\ActivityLogCommand();
         $commands[] = new Command\App\AppConfigGetCommand();
@@ -213,8 +214,7 @@ class Application extends ParentApplication
      */
     public function doRunCommand(ConsoleCommand $command, InputInterface $input, OutputInterface $output)
     {
-        // There is a runningCommand property, but it is private.
-        $this->currentCommand = $command;
+        $this->setCurrentCommand($command);
 
         // Build the command synopsis early, so it doesn't include default
         // options and arguments (such as --help and <command>).
@@ -222,6 +222,18 @@ class Application extends ParentApplication
         $this->currentCommand->getSynopsis();
 
         return parent::doRunCommand($command, $input, $output);
+    }
+
+    /**
+     * Set the current command. This is used for error handling.
+     *
+     * @param ConsoleCommand|null $command
+     */
+    public function setCurrentCommand(ConsoleCommand $command = null)
+    {
+        // The parent class has a similar (private) property named
+        // $runningCommand.
+        $this->currentCommand = $command;
     }
 
     /**
@@ -328,7 +340,7 @@ class Application extends ParentApplication
             }
         } while ($e = $e->getPrevious());
 
-        if (null !== $this->currentCommand && $this->currentCommand->getName() !== 'welcome') {
+        if (null !== $this->currentCommand) {
             $output->writeln(sprintf('Usage: <info>%s</info>', $this->currentCommand->getSynopsis()), OutputInterface::VERBOSITY_QUIET);
             $output->writeln('', OutputInterface::VERBOSITY_QUIET);
             $output->writeln(sprintf('For more information, type: <info>%s help %s</info>', $this->cliConfig->get('application.executable'), $this->currentCommand->getName()), OutputInterface::VERBOSITY_QUIET);

--- a/src/Application.php
+++ b/src/Application.php
@@ -212,7 +212,7 @@ class Application extends ParentApplication
     /**
      * {@inheritdoc}
      */
-    public function doRunCommand(ConsoleCommand $command, InputInterface $input, OutputInterface $output)
+    protected function doRunCommand(ConsoleCommand $command, InputInterface $input, OutputInterface $output)
     {
         $this->setCurrentCommand($command);
 

--- a/src/Command/Activity/ActivityListCommand.php
+++ b/src/Command/Activity/ActivityListCommand.php
@@ -35,7 +35,7 @@ class ActivityListCommand extends CommandBase
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->validateInput($input, !$input->getOption('all'));
+        $this->validateInput($input, $input->getOption('all'));
 
         $project = $this->getSelectedProject();
 

--- a/src/Command/Activity/ActivityLogCommand.php
+++ b/src/Command/Activity/ActivityLogCommand.php
@@ -70,7 +70,7 @@ class ActivityLogCommand extends CommandBase
         );
 
         $refresh = $input->getOption('refresh');
-        if ($refresh > 0 && $this->isTerminal($output) && !$activity->isComplete()) {
+        if ($refresh > 0 && !$this->runningViaMulti && $this->isTerminal($output) && !$activity->isComplete()) {
             $activity->wait(
                 null,
                 function ($log) use ($output) {

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -57,6 +57,7 @@ abstract class CommandBase extends Command implements CanHideInListInterface, Mu
     protected $hiddenInList = false;
     protected $local = false;
     protected $canBeRunMultipleTimes = true;
+    protected $runningViaMulti = false;
 
     /** @var CliConfig */
     protected static $config;
@@ -1021,5 +1022,13 @@ abstract class CommandBase extends Command implements CanHideInListInterface, Mu
     public function canBeRunMultipleTimes()
     {
         return $this->canBeRunMultipleTimes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRunningViaMulti($runningViaMulti = true)
+    {
+        $this->runningViaMulti = $runningViaMulti;
     }
 }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Yaml\Yaml;
 
-abstract class CommandBase extends Command implements CanHideInListInterface
+abstract class CommandBase extends Command implements CanHideInListInterface, MultiAwareInterface
 {
     use HasExamplesTrait;
 
@@ -56,6 +56,7 @@ abstract class CommandBase extends Command implements CanHideInListInterface
     protected $envArgName = 'environment';
     protected $hiddenInList = false;
     protected $local = false;
+    protected $canBeRunMultipleTimes = true;
 
     /** @var CliConfig */
     protected static $config;
@@ -915,8 +916,9 @@ abstract class CommandBase extends Command implements CanHideInListInterface
      */
     protected function runOtherCommand($name, array $arguments = [], OutputInterface $output = null)
     {
-        /** @var CommandBase $command */
-        $command = $this->getApplication()->find($name);
+        /** @var \Platformsh\Cli\Application $application */
+        $application = $this->getApplication();
+        $command = $application->find($name);
 
         // Pass on interactivity arguments to the other command.
         if (isset($this->input)) {
@@ -931,7 +933,11 @@ abstract class CommandBase extends Command implements CanHideInListInterface
 
         $this->debug('Running command: ' . $name);
 
-        return $command->run($cmdInput, $output ?: $this->output);
+        $application->setCurrentCommand($command);
+        $result = $command->run($cmdInput, $output ?: $this->output);
+        $application->setCurrentCommand($this);
+
+        return $result;
     }
 
     /**
@@ -1007,5 +1013,13 @@ abstract class CommandBase extends Command implements CanHideInListInterface
         }
 
         return $helper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canBeRunMultipleTimes()
+    {
+        return $this->canBeRunMultipleTimes;
     }
 }

--- a/src/Command/Environment/EnvironmentInfoCommand.php
+++ b/src/Command/Environment/EnvironmentInfoCommand.php
@@ -6,7 +6,6 @@ use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Util\ActivityUtil;
 use Platformsh\Cli\Util\Table;
 use Platformsh\Cli\Util\PropertyFormatter;
-use Platformsh\Cli\Util\Util;
 use Platformsh\Client\Model\Environment;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -64,13 +63,7 @@ class EnvironmentInfoCommand extends CommandBase
             return $this->setProperty($property, $value, $environment, $input->getOption('no-wait'));
         }
 
-        $data = $environment->getProperties();
-        $value = Util::getNestedArrayValue($data, explode('.', $property), $exists);
-        if (!$exists) {
-            $this->stdErr->writeln("Property not found: <error>$property</error>");
-
-            return 1;
-        }
+        $value = $this->api()->getNestedProperty($environment, $property);
 
         $output->writeln($this->formatter->format($value, $property));
 

--- a/src/Command/Environment/EnvironmentLogCommand.php
+++ b/src/Command/Environment/EnvironmentLogCommand.php
@@ -35,6 +35,10 @@ class EnvironmentLogCommand extends CommandBase implements CompletionAwareInterf
     {
         $this->validateInput($input);
 
+        if ($input->getOption('tail') && $this->runningViaMulti) {
+            throw new \InvalidArgumentException('The --tail option cannot be used with "multi"');
+        }
+
         $selectedEnvironment = $this->getSelectedEnvironment();
         $appName = $this->selectApp($input);
         $sshUrl = $selectedEnvironment->getSshUrl($appName);
@@ -74,7 +78,7 @@ class EnvironmentLogCommand extends CommandBase implements CompletionAwareInterf
 
         $command = sprintf('tail -n %d %s', $input->getOption('lines'), escapeshellarg($logFilename));
         if ($input->getOption('tail')) {
-             $command .= ' -f';
+            $command .= ' -f';
         }
 
         $this->stdErr->writeln(sprintf('Reading log file <info>%s:%s</info>', $sshUrl, $logFilename));

--- a/src/Command/Environment/EnvironmentSqlCommand.php
+++ b/src/Command/Environment/EnvironmentSqlCommand.php
@@ -26,6 +26,9 @@ class EnvironmentSqlCommand extends CommandBase
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->validateInput($input);
+        if (!$input->getArgument('query') && $this->runningViaMulti) {
+            throw new \InvalidArgumentException('The query argument is required when running via "multi"');
+        }
 
         $sshOptions = '';
 

--- a/src/Command/Environment/EnvironmentSshCommand.php
+++ b/src/Command/Environment/EnvironmentSshCommand.php
@@ -44,6 +44,10 @@ class EnvironmentSshCommand extends CommandBase
         }
 
         $remoteCommand = $input->getArgument('cmd');
+        if (!$remoteCommand && $this->runningViaMulti) {
+            throw new \InvalidArgumentException('The cmd argument is required when running via "multi"');
+        }
+
         if ($input instanceof ArgvInput) {
             $helper = new ArgvHelper();
             $remoteCommand = $helper->getPassedCommand($this, $input);

--- a/src/Command/Integration/IntegrationGetCommand.php
+++ b/src/Command/Integration/IntegrationGetCommand.php
@@ -2,7 +2,6 @@
 namespace Platformsh\Cli\Command\Integration;
 
 use Platformsh\Cli\Util\Table;
-use Platformsh\Cli\Util\Util;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -60,13 +59,7 @@ class IntegrationGetCommand extends IntegrationCommandBase
                 $value = $integration->getLink('#hook');
             }
             else {
-                $data = $integration->getProperties();
-                $value = Util::getNestedArrayValue($data, explode('.', $property), $exists);
-                if (!$exists) {
-                    $this->stdErr->writeln("Integration property not found: <error>$property</error>");
-
-                    return 1;
-                }
+                $value = $this->api()->getNestedProperty($integration, $property);
             }
 
             $output->writeln($this->propertyFormatter->format($value, $property));

--- a/src/Command/MultiAwareInterface.php
+++ b/src/Command/MultiAwareInterface.php
@@ -9,4 +9,9 @@ interface MultiAwareInterface
      * @return bool
      */
     public function canBeRunMultipleTimes();
+
+    /**
+     * @param bool $runningViaMulti
+     */
+    public function setRunningViaMulti($runningViaMulti = true);
 }

--- a/src/Command/MultiAwareInterface.php
+++ b/src/Command/MultiAwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace Platformsh\Cli\Command;
+
+interface MultiAwareInterface
+{
+    /**
+     * Whether the command can be run multiple times in one process.
+     *
+     * @return bool
+     */
+    public function canBeRunMultipleTimes();
+}

--- a/src/Command/MultiCommand.php
+++ b/src/Command/MultiCommand.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Platformsh\Cli\Command;
+
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MultiCommand extends CommandBase implements CompletionAwareInterface
+{
+    protected $hiddenInList = true;
+    protected $canBeRunMultipleTimes = false;
+
+    protected function configure()
+    {
+        $this
+            ->setName('multi')
+            ->setDescription('Execute a command on multiple projects')
+            ->addArgument('cmd', InputArgument::REQUIRED, 'The command to execute')
+            ->addOption('projects', 'p', InputOption::VALUE_REQUIRED, 'A list of project IDs, separated by commas and/or whitespace')
+            ->addOption('continue', 'c', InputOption::VALUE_NONE, 'Continue running commands even if an exception is encountered')
+            ->addOption('sort', null, InputOption::VALUE_REQUIRED, 'A property by which to sort the list of project options', 'title')
+            ->addOption('reverse', null, InputOption::VALUE_NONE, 'Reverse the order of project options');
+        $this->addExample('List variables on the "master" environment for multiple projects', "--projects l7ywemwizmmgb,o43m25zns6k2d,3nyujoslhydhx 'variable:get --environment master'");
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $commandLine = $input->getArgument('cmd');
+        $commandArgs = explode(' ', $commandLine);
+        $commandName = reset($commandArgs);
+        if (!$commandName) {
+            throw new \InvalidArgumentException('Invalid command: ' . $commandLine);
+        }
+        /** @var \Platformsh\Cli\Application $application */
+        $application = $this->getApplication();
+        $command = $application->find($commandName);
+        if (!$command instanceof MultiAwareInterface || !$command->canBeRunMultipleTimes()) {
+            $this->stdErr->writeln(sprintf('The command <error>%s</error> cannot be run via "%s multi".', $commandName, self::$config->get('application.executable')));
+            return 1;
+        }
+        elseif (!$command->getDefinition()->hasOption('project')) {
+            $this->stdErr->writeln(sprintf('The command <error>%s</error> does not have a --project option.', $commandName));
+            return 1;
+        }
+
+        $projects = $this->getSelectedProjects($input);
+        if ($projects === false) {
+            return 1;
+        }
+
+        $success = true;
+        $continue = $input->getOption('continue');
+        $output->writeln(sprintf(
+            "Running command '%s' on %d %s.",
+            $commandLine,
+            count($projects),
+            count($projects) === 1 ? 'project' : 'projects'
+        ));
+        foreach ($projects as $project) {
+            $output->writeln('');
+            $output->writeln('Project: <options=reverse>' . $project->id . '</>' . ($project->title ? ' (' . $project->title . ')' : ''));
+            try {
+                $application->setCurrentCommand($command);
+                $commandInput = new StringInput($commandLine . ' --project ' . escapeshellarg($project->id));
+                $returnCode = $command->run($commandInput, $this->output);
+                $application->setCurrentCommand($this);
+                if ($returnCode !== 0) {
+                    $success = false;
+                }
+            }
+            catch (\Exception $e) {
+                if (!$continue) {
+                    throw $e;
+                }
+                $this->getApplication()->renderException($e, $this->stdErr);
+                $success = false;
+            }
+        }
+
+        return $success ? 0 : 1;
+    }
+
+    /**
+     * Show a checklist using the dialog utility.
+     *
+     * @param string $text
+     * @param array  $options
+     *
+     * @return array
+     */
+    protected function showDialogChecklist(array $options, $text = 'Choose item(s)')
+    {
+        $width = 80;
+        $height = 20;
+        $listHeight = 20;
+        $command = sprintf(
+            'dialog --separate-output --checklist %s %d %d %d',
+            escapeshellarg($text),
+            $height,
+            $width,
+            $listHeight
+        );
+        foreach ($options as $tag => $option) {
+            $command .= sprintf(' %s %s off', escapeshellarg($tag), escapeshellarg($option));
+        }
+
+        $env = null;
+
+        $dialogRc = file_get_contents(CLI_ROOT . '/resources/console/dialogrc');
+        $dialogRcFile = $this->getUserConfigDir() . '/dialogrc';
+        if ($dialogRc !== false && (file_exists($dialogRcFile) || file_put_contents($dialogRcFile, $dialogRc))) {
+            $env = $_ENV + ['DIALOGRC' => $dialogRcFile];
+        }
+
+        $pipes = [2 => null];
+        $process = proc_open($command, [
+            2 => array('pipe', 'w'),
+        ], $pipes, null, $env);
+
+        // Wait for and read result.
+        $result = array_filter(explode("\n", trim(stream_get_contents($pipes[2]))));
+
+        // Close handles.
+        if (is_resource($pipes[2])) {
+            fclose($pipes[2]);
+        }
+
+        proc_close($process);
+
+        $this->stdErr->writeln('');
+
+        return $result;
+    }
+
+    /**
+     * Get a list of the user's projects, sorted according to the input.
+     *
+     * @param InputInterface $input
+     *
+     * @return \Platformsh\Client\Model\Project[]
+     */
+    protected function getAllProjects(InputInterface $input)
+    {
+        $projects = $this->api()->getProjects();
+        if ($input->getOption('sort')) {
+            $this->api()->sortResources($projects, $input->getOption('sort'));
+        }
+        if ($input->getOption('reverse')) {
+            $projects = array_reverse($projects, true);
+        }
+
+        return $projects;
+    }
+
+    /**
+     * Get the projects selected by the user.
+     *
+     * Projects can be specified via the command-line option --projects (as a
+     * list of project IDs) or, if possible, the user will be prompted with a
+     * checklist via the 'dialog' utility.
+     *
+     * @param InputInterface $input
+     *
+     * @return \Platformsh\Client\Model\Project[]|false
+     *   An array of projects, or false on error.
+     */
+    protected function getSelectedProjects(InputInterface $input)
+    {
+        $projectList = $input->getOption('projects');
+        $projects = $this->getAllProjects($input);
+
+        if (!empty($projectList)) {
+            $projectIds = array_unique(preg_split('/[,\s]+/', $projectList));
+            if ($invalid = array_diff($projectIds, array_keys($projects))) {
+                $this->stdErr->writeln(sprintf('Project ID(s) not found: <error>%s</error>', implode(', ', $invalid)));
+                return false;
+            }
+        }
+        elseif (!$input->isInteractive()) {
+            $this->stdErr->writeln('In non-interactive mode, the --projects option must be specified.');
+            return false;
+        }
+        elseif (!$this->getHelper('shell')->commandExists('dialog')) {
+            $this->stdErr->writeln('The "dialog" utility is required for interactive use.');
+            $this->stdErr->writeln('You can specify projects via the --projects option.');
+            return false;
+        }
+        else {
+            $projectOptions = [];
+            foreach ($projects as $project) {
+                $projectOptions[$project->id] = $project->title ?: $project->id;
+            }
+
+            $projectIds = $this->showDialogChecklist($projectOptions, 'Choose one or more projects');
+            if (empty($projectIds)) {
+                return false;
+            }
+            $this->stdErr->writeln('Selected project(s): ' . implode(',', $projectIds));
+            $this->stdErr->writeln('');
+        }
+
+        return array_intersect_key($projects, array_flip($projectIds));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'cmd') {
+            $commandNames = [];
+            foreach ($this->getApplication()->all() as $command) {
+                if ($command instanceof MultiAwareInterface && $command->canBeRunMultipleTimes() && $command->getDefinition()->hasOption('project')) {
+                    $commandNames[] = $command->getName();
+                }
+            }
+
+            return $commandNames;
+        }
+
+        return [];
+    }
+}

--- a/src/Command/MultiCommand.php
+++ b/src/Command/MultiCommand.php
@@ -63,10 +63,13 @@ class MultiCommand extends CommandBase implements CompletionAwareInterface
         ));
         foreach ($projects as $project) {
             $output->writeln('');
-            $output->writeln('Project: <options=reverse>' . $project->id . '</>' . ($project->title ? ' (' . $project->title . ')' : ''));
+            $output->writeln('<options=reverse>*</> Project: ' . $project->id . ($project->title ? ' (' . $project->title . ')' : ''));
             try {
                 $application->setCurrentCommand($command);
                 $commandInput = new StringInput($commandLine . ' --project ' . escapeshellarg($project->id));
+                if ($command instanceof MultiAwareInterface) {
+                    $command->setRunningViaMulti(true);
+                }
                 $returnCode = $command->run($commandInput, $this->output);
                 $application->setCurrentCommand($this);
                 if ($returnCode !== 0) {

--- a/src/Command/Project/ProjectInfoCommand.php
+++ b/src/Command/Project/ProjectInfoCommand.php
@@ -6,7 +6,6 @@ use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Util\ActivityUtil;
 use Platformsh\Cli\Util\Table;
 use Platformsh\Cli\Util\PropertyFormatter;
-use Platformsh\Cli\Util\Util;
 use Platformsh\Client\Model\Project;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -65,18 +64,7 @@ class ProjectInfoCommand extends CommandBase
                 break;
 
             default:
-                $data = $project->getProperties(false);
-                $value = Util::getNestedArrayValue($data, explode('.', $property), $exists);
-                if (!$exists) {
-                    // Add data from the main resource and try again.
-                    $data = array_merge($data, $project->getProperties(true));
-                    $value = Util::getNestedArrayValue($data, explode('.', $property), $exists);
-                    if (!$exists) {
-                        $this->stdErr->writeln('Property not found: <error>' . $property . '</error>');
-
-                        return 1;
-                    }
-                }
+                $value = $this->api()->getNestedProperty($project, $property);
         }
 
         $output->writeln($this->formatter->format($value, $property));

--- a/src/Command/SubscriptionInfoCommand.php
+++ b/src/Command/SubscriptionInfoCommand.php
@@ -5,7 +5,6 @@ namespace Platformsh\Cli\Command;
 use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Util\Table;
 use Platformsh\Cli\Util\PropertyFormatter;
-use Platformsh\Cli\Util\Util;
 use Platformsh\Client\Model\Subscription;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -54,13 +53,7 @@ class SubscriptionInfoCommand extends CommandBase
             return $this->listProperties($subscription, new Table($input, $output));
         }
 
-        $data = $subscription->getProperties();
-        $value = Util::getNestedArrayValue($data, explode('.', $property), $exists);
-        if (!$exists) {
-            $this->stdErr->writeln('Property not found: <error>' . $property . '</error>');
-
-            return 1;
-        }
+        $value = $this->api()->getNestedProperty($subscription, $property);
 
         $output->writeln($this->formatter->format($value, $property));
 

--- a/src/Command/Tunnel/TunnelCommandBase.php
+++ b/src/Command/Tunnel/TunnelCommandBase.php
@@ -13,6 +13,7 @@ abstract class TunnelCommandBase extends CommandBase
     const LOCAL_IP = '127.0.0.1';
 
     protected $tunnelInfo;
+    protected $canBeRunMultipleTimes = false;
 
     public function checkSupport()
     {


### PR DESCRIPTION
- [x] Improve interactive selection, a lot
- [x] Exclude commands that won't work as part of a single process
- [x] Support sorting the projects list
- [ ] ~~Fork and run commands concurrently, where possible?~~
- [x] What about combinations of options within a command that result in nonsensical behaviour with `multi`? e.g. `environment:logs --tail`?