### PR TITLE
Only remove the previous build when the new one completes

### DIFF
--- a/src/Local/Toolstack/ToolstackBase.php
+++ b/src/Local/Toolstack/ToolstackBase.php
@@ -124,10 +124,18 @@ abstract class ToolstackBase implements ToolstackInterface
         }
         $this->ignoredFiles[] = $this->config->get('local.web_root');
 
-        $this->buildDir = $buildDir;
+        $this->setBuildDir($buildDir);
 
         $this->copy = !empty($settings['copy']);
         $this->fsHelper->setRelativeLinks(empty($settings['absoluteLinks']));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setBuildDir($buildDir)
+    {
+        $this->buildDir = $buildDir;
     }
 
     /**

--- a/src/Local/Toolstack/ToolstackInterface.php
+++ b/src/Local/Toolstack/ToolstackInterface.php
@@ -46,6 +46,13 @@ interface ToolstackInterface
     public function prepare($buildDir, LocalApplication $app, CliConfig $config, array $settings = []);
 
     /**
+     * Set the build directory.
+     *
+     * @param string $buildDir
+     */
+    public function setBuildDir($buildDir);
+
+    /**
      * Build this application. Acquire dependencies, plugins, libraries, and
      * submodules.
      */


### PR DESCRIPTION
* Main advantage: confuses PhpStorm less (the build symlink is broken for a much shorter time)
* This was always my original intention, it got left out somehow...