### PR TITLE
Remove minimum Drush version check

### DIFF
--- a/src/Exception/DependencyVersionMisMatchException.php
+++ b/src/Exception/DependencyVersionMisMatchException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Platformsh\Cli\Exception;
-
-class DependencyVersionMismatchException extends \RuntimeException
-{
-    protected $code = 8;
-}


### PR DESCRIPTION
* It caused problems, e.g. #463 
* We don't check for other dependency versions (npm, Composer, etc.)
* Eventually, we should be able to read the config and install/ensure build dependencies automatically where needed (#396)