### PR TITLE
Explicitly check the PHP version when running the CLI tool

### DIFF
--- a/bin/platform
+++ b/bin/platform
@@ -6,7 +6,7 @@ ini_set('display_errors', 1);
 ini_set('log_errors', 0);
 
 if (version_compare(PHP_VERSION, '5.5.9', '<')) {
-    echo "The Platform.sh CLI tool requires at least PHP 5.5.9. Please upgrade your PHP version.\n";
+    echo "This tool requires at least PHP 5.5.9. Please upgrade your PHP version.\n";
     exit(1);
 }
 

--- a/bin/platform
+++ b/bin/platform
@@ -6,7 +6,7 @@ ini_set('display_errors', 1);
 ini_set('log_errors', 0);
 
 if (version_compare(PHP_VERSION, '5.5.9', '<')) {
-    echo "This tool requires at least PHP 5.5.9. Please upgrade your PHP version.\n";
+    printf("This tool requires at least PHP 5.5.9. You currently have %s installed. Please upgrade your PHP version.\n", PHP_VERSION);
     exit(1);
 }
 

--- a/bin/platform
+++ b/bin/platform
@@ -5,6 +5,11 @@
 ini_set('display_errors', 1);
 ini_set('log_errors', 0);
 
+if (version_compare(PHP_VERSION, '5.5.9', '<')) {
+    echo "The Platform.sh CLI tool requires at least PHP 5.5.9. Please upgrade your PHP version.\n";
+    exit(1);
+}
+
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
 } elseif (file_exists(__DIR__ . '/../../../autoload.php')) {

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Platform.sh CLI",
     "license": "MIT",
     "require": {
+        "php": ">=5.5.9",
         "doctrine/cache": "~1.5",
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",


### PR DESCRIPTION
That way people don't get confusing syntax errors if they're on an ancient Mac with PHP 5.3 installed... (Not that I have seen someone do that, not at all...)