### PR TITLE
Improve activities batch performance

### DIFF
--- a/src/Command/Domain/DomainAddCommand.php
+++ b/src/Command/Domain/DomainAddCommand.php
@@ -58,7 +58,7 @@ class DomainAddCommand extends DomainCommandBase
         }
 
         if (!$input->getOption('no-wait')) {
-            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $project);
         }
 
         return 0;

--- a/src/Command/Domain/DomainDeleteCommand.php
+++ b/src/Command/Domain/DomainDeleteCommand.php
@@ -48,7 +48,7 @@ class DomainDeleteCommand extends CommandBase
         $this->stdErr->writeln("The domain <info>$name</info> has been deleted.");
 
         if (!$input->getOption('no-wait')) {
-            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $project);
         }
 
         return 0;

--- a/src/Command/Domain/DomainUpdateCommand.php
+++ b/src/Command/Domain/DomainUpdateCommand.php
@@ -60,7 +60,7 @@ class DomainUpdateCommand extends DomainCommandBase
         $result = $domain->update(['ssl' => $this->sslOptions]);
 
         if (!$input->getOption('no-wait')) {
-            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $project);
         }
 
         return 0;

--- a/src/Command/Environment/EnvironmentActivateCommand.php
+++ b/src/Command/Environment/EnvironmentActivateCommand.php
@@ -92,7 +92,7 @@ class EnvironmentActivateCommand extends CommandBase
         $success = true;
         if ($processed) {
             if (!$input->getOption('no-wait')) {
-                $success = ActivityUtil::waitMultiple($activities, $output);
+                ActivityUtil::waitMultiple($activities, $this->stdErr, $this->getSelectedProject());
             }
             $this->api()->clearEnvironmentsCache($this->getSelectedProject()->id);
         }

--- a/src/Command/Environment/EnvironmentDeleteCommand.php
+++ b/src/Command/Environment/EnvironmentDeleteCommand.php
@@ -220,7 +220,7 @@ EOF
         }
 
         if (!$input->getOption('no-wait')) {
-            if (!ActivityUtil::waitMultiple($deactivateActivities, $output)) {
+            if (!ActivityUtil::waitMultiple($deactivateActivities, $output, $this->getSelectedProject())) {
                 $error = true;
             }
         }

--- a/src/Command/Environment/EnvironmentHttpAccessCommand.php
+++ b/src/Command/Environment/EnvironmentHttpAccessCommand.php
@@ -200,7 +200,7 @@ class EnvironmentHttpAccessCommand extends CommandBase
                     $this->rebuildWarning();
                 }
                 elseif (!$input->getOption('no-wait')) {
-                    $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+                    $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $this->getSelectedProject());
                 }
 
                 return $success ? 0 : 1;

--- a/src/Command/Environment/EnvironmentInfoCommand.php
+++ b/src/Command/Environment/EnvironmentInfoCommand.php
@@ -125,7 +125,7 @@ class EnvironmentInfoCommand extends CommandBase
         $rebuildProperties = ['enable_smtp', 'restrict_robots'];
         $success = true;
         if ($result->countActivities() && !$noWait) {
-            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $this->getSelectedProject());
         }
         elseif (!$result->countActivities() && in_array($property, $rebuildProperties)) {
             $this->rebuildWarning();

--- a/src/Command/Integration/IntegrationAddCommand.php
+++ b/src/Command/Integration/IntegrationAddCommand.php
@@ -41,7 +41,7 @@ class IntegrationAddCommand extends IntegrationCommandBase
 
         $success = true;
         if (!$input->getOption('no-wait')) {
-            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $this->getSelectedProject());
         }
 
         $this->displayIntegration($integration, $input, $this->stdErr);

--- a/src/Command/Integration/IntegrationDeleteCommand.php
+++ b/src/Command/Integration/IntegrationDeleteCommand.php
@@ -46,7 +46,7 @@ class IntegrationDeleteCommand extends CommandBase
         $this->stdErr->writeln("Deleted integration <info>$id</info>");
 
         if (!$input->getOption('no-wait')) {
-            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $this->getSelectedProject());
         }
 
         return 0;

--- a/src/Command/Integration/IntegrationUpdateCommand.php
+++ b/src/Command/Integration/IntegrationUpdateCommand.php
@@ -65,7 +65,7 @@ class IntegrationUpdateCommand extends IntegrationCommandBase
         $this->displayIntegration($integration, $input, $this->stdErr);
 
         if (!$input->getOption('no-wait')) {
-            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $this->getSelectedProject());
         }
 
         return 0;

--- a/src/Command/Project/ProjectInfoCommand.php
+++ b/src/Command/Project/ProjectInfoCommand.php
@@ -127,7 +127,7 @@ class ProjectInfoCommand extends CommandBase
 
         $success = true;
         if (!$noWait) {
-            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $project);
         }
 
         return $success ? 0 : 1;

--- a/src/Command/User/UserAddCommand.php
+++ b/src/Command/User/UserAddCommand.php
@@ -143,7 +143,7 @@ class UserAddCommand extends CommandBase
         }
 
         if (!$input->getOption('no-wait')) {
-            if (!ActivityUtil::waitMultiple($activities, $this->stdErr)) {
+            if (!ActivityUtil::waitMultiple($activities, $this->stdErr, $project)) {
                 $success = false;
             }
         }

--- a/src/Command/User/UserDeleteCommand.php
+++ b/src/Command/User/UserDeleteCommand.php
@@ -55,7 +55,7 @@ class UserDeleteCommand extends CommandBase
         $this->stdErr->writeln("User <info>$email</info> deleted");
 
         if (!$input->getOption('no-wait')) {
-            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $project);
         }
 
         // If the user was deleting themselves from the project, then invalidate

--- a/src/Command/User/UserRoleCommand.php
+++ b/src/Command/User/UserRoleCommand.php
@@ -129,7 +129,7 @@ class UserRoleCommand extends CommandBase
         }
 
         if (isset($result) && !$input->getOption('no-wait')) {
-            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $project);
         }
 
         if ($input->getOption('pipe')) {

--- a/src/Command/Variable/VariableDeleteCommand.php
+++ b/src/Command/Variable/VariableDeleteCommand.php
@@ -72,7 +72,7 @@ class VariableDeleteCommand extends CommandBase
             $this->rebuildWarning();
         }
         elseif (!$input->getOption('no-wait')) {
-            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $this->getSelectedProject());
         }
 
         return $success ? 0 : 1;

--- a/src/Command/Variable/VariableSetCommand.php
+++ b/src/Command/Variable/VariableSetCommand.php
@@ -66,7 +66,7 @@ class VariableSetCommand extends CommandBase
             $this->rebuildWarning();
         }
         elseif (!$input->getOption('no-wait')) {
-            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr);
+            $success = ActivityUtil::waitMultiple($result->getActivities(), $this->stdErr, $this->getSelectedProject());
         }
 
         return $success ? 0 : 1;


### PR DESCRIPTION
When waiting for 20 activities, this would reduce API calls from <= 20 on each check (every second) to <= ~11 on each.