### PR TITLE
Option for not deleting remote branch

### DIFF
--- a/src/Command/Environment/EnvironmentDeleteCommand.php
+++ b/src/Command/Environment/EnvironmentDeleteCommand.php
@@ -191,7 +191,7 @@ EOF
                 if ($questionHelper->confirm("Are you sure you want to delete the environment <comment>$environmentId</comment>?")) {
                     $deactivate[$environmentId] = $environment;
                     if (!$input->getOption('no-delete-branch')) {
-                        if ($input->getOption('delete-branch') || ($input->isInteractive() && $questionHelper->confirm("Delete the remote Git branch too?", false))) {
+                        if ($input->getOption('delete-branch') || ($input->isInteractive() && $questionHelper->confirm("Delete the remote Git branch too?"))) {
                             $delete[$environmentId] = $environment;
                         }
                     }

--- a/src/Command/Environment/EnvironmentDeleteCommand.php
+++ b/src/Command/Environment/EnvironmentDeleteCommand.php
@@ -20,6 +20,7 @@ class EnvironmentDeleteCommand extends CommandBase
             ->setDescription('Delete an environment')
             ->addArgument('environment', InputArgument::IS_ARRAY, 'The environment(s) to delete')
             ->addOption('delete-branch', null, InputOption::VALUE_NONE, 'Delete the remote Git branch(es) too')
+            ->addOption('no-delete-branch', null, InputOption::VALUE_NONE, 'Do not delete the remote Git branch(es)')
             ->addOption('inactive', null, InputOption::VALUE_NONE, 'Delete all inactive environments')
             ->addOption('merged', null, InputOption::VALUE_NONE, 'Delete all merged environments')
             ->addOption('exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Environments not to delete');
@@ -189,8 +190,10 @@ EOF
                 $output->writeln("The environment <comment>$environmentId</comment> is currently active: deleting it will delete all associated data.");
                 if ($questionHelper->confirm("Are you sure you want to delete the environment <comment>$environmentId</comment>?")) {
                     $deactivate[$environmentId] = $environment;
-                    if ($input->getOption('delete-branch') || ($input->isInteractive() && $questionHelper->confirm("Delete the remote Git branch too?"))) {
-                        $delete[$environmentId] = $environment;
+                    if (!$input->getOption('no-delete-branch')) {
+                        if ($input->getOption('delete-branch') || ($input->isInteractive() && $questionHelper->confirm("Delete the remote Git branch too?", false))) {
+                            $delete[$environmentId] = $environment;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I think removing the remote branch by default when removing is dangerous. It's not often, but we are enforcing a feature-branching model, and it's possible that we would want some features to be kept remotely without an environment.

Also I noticed that although there are --yes, --no and --delete-branch, we don't really have a way to not delete it from the command line. So added that option as well.