### PR TITLE
Create CLI command for quick-read on SQL disk usage.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -132,6 +132,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Environment\EnvironmentSshCommand();
         $commands[] = new Command\Environment\EnvironmentSqlCommand();
         $commands[] = new Command\Environment\EnvironmentSqlDumpCommand();
+        $commands[] = new Command\Environment\EnvironmentSqlSizeCommand();
         $commands[] = new Command\Environment\EnvironmentSynchronizeCommand();
         $commands[] = new Command\Environment\EnvironmentUrlCommand();
         $commands[] = new Command\Environment\EnvironmentSetRemoteCommand();

--- a/src/Command/Environment/EnvironmentDrushCommand.php
+++ b/src/Command/Environment/EnvironmentDrushCommand.php
@@ -74,19 +74,7 @@ class EnvironmentDrushCommand extends CommandBase
         // available.
         $projectRoot = $this->getProjectRoot();
         if ($projectRoot && $this->selectedProjectIsCurrent()) {
-            $apps = LocalApplication::getApplications($projectRoot, self::$config);
-            /** @var LocalApplication $app */
-            if (count($apps) === 1 && $appName === null) {
-                $app = reset($apps);
-            }
-            else {
-                foreach ($apps as $possibleApp) {
-                    if ($possibleApp->getName() === $appName) {
-                        $app = $possibleApp;
-                        break;
-                    }
-                }
-            }
+            $app = LocalApplication::getApplication($appName, $projectRoot, self::$config);
         }
 
         // Use the local application configuration (if available) to determine

--- a/src/Command/Environment/EnvironmentSqlSizeCommand.php
+++ b/src/Command/Environment/EnvironmentSqlSizeCommand.php
@@ -7,7 +7,6 @@ use Platformsh\Cli\Helper\ShellHelper;
 use Platformsh\Cli\Util\RelationshipsUtil;
 use Platformsh\Cli\Util\Table;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
@@ -32,8 +31,6 @@ class EnvironmentSqlSizeCommand extends CommandBase {
 
         /** @var ShellHelper $shellHelper */
         $shellHelper = $this->getHelper('shell');
-        $bufferedOutput = new BufferedOutput();
-        $shellHelper->setOutput($bufferedOutput);
 
         // Get and parse app config.
         $args = ['ssh', $sshUrl, 'echo $' . self::$config->get('service.env_prefix') . 'APPLICATION'];

--- a/src/Command/Environment/EnvironmentSqlSizeCommand.php
+++ b/src/Command/Environment/EnvironmentSqlSizeCommand.php
@@ -1,0 +1,160 @@
+<?php
+namespace Platformsh\Cli\Command\Environment;
+
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Helper\ShellHelper;
+use Platformsh\Cli\Util\RelationshipsUtil;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnvironmentSqlSizeCommand extends CommandBase {
+
+    protected function configure() {
+        $this
+            ->setName('environment:sql-size')
+            ->setAliases(['sqls'])
+            ->setDescription('Database size check')
+            ->addOption('details', 'd', InputOption::VALUE_NONE, 'Show detailed (per table) report.')
+            ->addOption('xml', 'x', InputOption::VALUE_NONE, 'Output results in XML (available for mysql databases only).');
+        $this->addProjectOption()->addEnvironmentOption()->addAppOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) {
+        $this->validateInput($input);
+        $sshUrl = $this->getSelectedEnvironment()
+            ->getSshUrl($this->selectApp($input));
+        $util = new RelationshipsUtil($this->stdErr);
+        $database = $util->chooseDatabase($sshUrl, $input);
+        if (empty($database)) {
+            return 1;
+        }
+
+        $command = ['ssh'];
+        // Switch on pseudo-tty allocation when there is a local tty.
+        if ($this->isTerminal($output)) {
+            $command[] = '-t';
+        }
+        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
+            $command[] = '-vv';
+        }
+        elseif ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
+            $command[] = '-v';
+        }
+        elseif ($output->getVerbosity() <= OutputInterface::VERBOSITY_VERBOSE) {
+            $command[] = '-q';
+        }
+        $command[] = $sshUrl;
+
+        switch ($database['scheme']) {
+            case 'pgsql':
+                if ($input->getOption('details')) {
+                    $query = $this->psqlQueryDetails();
+                }
+                else {
+                    $query = $this->psqlQueryOverview();
+                }
+                $command[] = "psql --echo-hidden postgresql://{$database['username']}:{$database['password']}@{$database['host']}/{$database['path']} -c \"$query\" 2>&1";
+                break;
+            default:
+                if ($input->getOption('details')) {
+                    $query = $this->mysqlQueryDetails();
+                }
+                else {
+                    $query = $this->mysqlQueryOverview();
+                }
+                $params = '--no-auto-rehash';
+                if ($input->getOption('xml')) {
+                    $params .= " --xml";
+                }
+                else {
+                    $params .= " --table";
+                }
+                $command[] = "mysql $params --database={$database['path']} --host={$database['host']} --port={$database['port']} --user={$database['username']} --password={$database['password']} --execute \"$query\" 2>&1";
+                break;
+        }
+
+        /** @var ShellHelper $shellHelper */
+        $shellHelper = $this->getHelper('shell');
+        $bufferedOutput = new BufferedOutput();
+        $shellHelper->setOutput($bufferedOutput);
+        $result = $shellHelper->execute($command);
+        // @todo: Parse the result, extract meaningful data.
+        $output->writeln($result);
+    }
+
+    private function psqlQueryOverview() {
+        return "
+          SELECT
+            pg_size_pretty(sum(pg_relation_size(pg_class.oid))::bigint) AS size,
+            nspname,
+            CASE pg_class.relkind
+              WHEN 'r' THEN 'table'
+              WHEN 'i' THEN 'index'
+              WHEN 'S' THEN 'sequence'
+              WHEN 'v' THEN 'view'
+              WHEN 't' THEN 'toast'
+              ELSE pg_class.relkind::text
+            END
+          FROM pg_class
+          LEFT OUTER JOIN pg_namespace ON (pg_namespace.oid = pg_class.relnamespace)
+          GROUP BY pg_class.relkind, nspname
+          ORDER BY sum(pg_relation_size(pg_class.oid)) DESC;
+        ";
+    }
+
+    private function psqlQueryDetails() {
+        return "
+          SELECT
+            *,
+            pg_size_pretty(total_bytes) AS total,
+            pg_size_pretty(index_bytes) AS INDEX,
+            pg_size_pretty(toast_bytes) AS toast,
+            pg_size_pretty(table_bytes) AS TABLE
+          FROM (
+            SELECT
+              *,
+              total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes
+            FROM (
+              SELECT
+                c.oid,nspname AS table_schema,
+                relname AS TABLE_NAME,
+                c.reltuples AS row_estimate,
+                pg_total_relation_size(c.oid) AS total_bytes,
+                pg_indexes_size(c.oid) AS index_bytes,
+                pg_total_relation_size(reltoastrelid) AS toast_bytes
+              FROM pg_class c
+              LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE relkind = 'r'
+            ) a
+          ) a;";
+    }
+
+    private function mysqlQueryOverview() {
+        return "
+          SELECT
+            SUM(index_length)/1048576                       AS index_length,
+            SUM(data_length)/1048576                        AS data_length,
+            SUM(data_free)/1048576                          AS data_free,
+            SUM(data_length+index_length+data_free)/1048576 AS disk_used,
+            (COUNT(*) * 300 * 1024)/1048576                 AS overhead,
+            (SUM(data_length+index_length+data_free) + (COUNT(*) * 300 * 1024))/1048576+150 as estimated_actual_disk_usage
+          FROM information_schema.tables
+          WHERE table_schema = 'main';";
+    }
+
+    private function mysqlQueryDetails() {
+        return "
+          SELECT 
+            table_name,
+            index_length/1048576                            AS index_length, 
+            data_length/1048576                             AS data_length,
+            data_free/1048576                               AS data_free,
+            (data_length+index_length)/1048576              AS data_used,
+            (data_length+index_length+data_free)/1048576    AS disk_used
+          FROM information_schema.tables
+          WHERE table_schema = 'main'
+          ORDER BY (data_length+index_length+data_free) ASC;";
+    }
+}

--- a/src/Command/Environment/EnvironmentSqlSizeCommand.php
+++ b/src/Command/Environment/EnvironmentSqlSizeCommand.php
@@ -18,7 +18,10 @@ class EnvironmentSqlSizeCommand extends CommandBase
         $this
             ->setName('environment:sql-size')
             ->setAliases(['sqls'])
-            ->setDescription('Estimate the disk usage of a database');
+            ->setDescription('Estimate the disk usage of a database')
+            ->setHelp(
+                "This command provides an estimate of the database's disk usage. It is not guaranteed to be reliable."
+            );
         $this->addProjectOption()->addEnvironmentOption()->addAppOption();
         Table::addFormatOption($this->getDefinition());
     }
@@ -53,6 +56,9 @@ class EnvironmentSqlSizeCommand extends CommandBase
         if (empty($database)) {
             return 1;
         }
+
+        $this->stdErr->write('Querying database <comment>' . $dbServiceName . '</comment> to estimate disk usage. ');
+        $this->stdErr->writeln('This might take a while.');
 
         $command = ['ssh'];
         // Switch on pseudo-tty allocation when there is a local tty.
@@ -94,8 +100,6 @@ class EnvironmentSqlSizeCommand extends CommandBase
             (int) $estimatedUsage . ($machineReadable ? '' : 'MB'),
             (int) $percentsUsed . '%',
         ];
-
-        $this->stdErr->writeln('Estimated disk usage for the database: <comment>' . $dbServiceName . '</comment>');
 
         $table->renderSimple($values, $propertyNames);
 

--- a/src/Command/Environment/EnvironmentSqlSizeCommand.php
+++ b/src/Command/Environment/EnvironmentSqlSizeCommand.php
@@ -69,9 +69,10 @@ class EnvironmentSqlSizeCommand extends CommandBase
 
         // Load services yaml.
         $services = Yaml::parse(file_get_contents($projectRoot . '/.platform/services.yaml'));
-        $allocatedDisk = $services[$dbServiceName]['disk'];
-        if(empty($allocatedDisk)) {
-            $this->stdErr->writeln('The disk size could not be estimated.');
+        if (!empty($services[$dbServiceName]['disk'])) {
+            $allocatedDisk = $services[$dbServiceName]['disk'];
+        } else {
+            $this->stdErr->writeln('The allocated disk size could not be determined for service: ' . $dbServiceName);
             return 1;
         }
 

--- a/src/Command/Environment/EnvironmentSqlSizeCommand.php
+++ b/src/Command/Environment/EnvironmentSqlSizeCommand.php
@@ -70,6 +70,10 @@ class EnvironmentSqlSizeCommand extends CommandBase
         // Load services yaml.
         $services = Yaml::parse(file_get_contents($projectRoot . '/.platform/services.yaml'));
         $allocatedDisk = $services[$dbServiceName]['disk'];
+        if(empty($allocatedDisk)) {
+            $this->stdErr->writeln('The disk size could not be estimated.');
+            return 1;
+        }
 
         $this->stdErr->write('Querying database <comment>' . $dbServiceName . '</comment> to estimate disk usage. ');
         $this->stdErr->writeln('This might take a while.');

--- a/src/Command/Environment/EnvironmentSqlSizeCommand.php
+++ b/src/Command/Environment/EnvironmentSqlSizeCommand.php
@@ -77,13 +77,6 @@ class EnvironmentSqlSizeCommand extends CommandBase
         /** @var ShellHelper $shellHelper */
         $shellHelper = $this->getHelper('shell');
         $command = ['ssh'];
-        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
-            $command[] = '-vv';
-        } elseif ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
-            $command[] = '-v';
-        } elseif ($output->getVerbosity() <= OutputInterface::VERBOSITY_VERBOSE) {
-            $command[] = '-q';
-        }
         $command[] = $sshUrl;
         switch ($database['scheme']) {
             case 'pgsql':

--- a/src/Local/LocalApplication.php
+++ b/src/Local/LocalApplication.php
@@ -233,7 +233,7 @@ class LocalApplication
      * @param CliConfig|null $config
      *     CLI configuration.
      *
-     * @return static[]
+     * @return LocalApplication[]
      */
     public static function getApplications($directory, CliConfig $config = null)
     {
@@ -252,8 +252,7 @@ class LocalApplication
         $applications = [];
         if ($finder->count() == 0) {
             $applications[$directory] = new LocalApplication($directory, $config, $directory);
-        }
-        else {
+        } else {
             /** @var \Symfony\Component\Finder\SplFileInfo $file */
             foreach ($finder as $file) {
                 $appRoot = dirname($file->getRealPath());
@@ -262,6 +261,33 @@ class LocalApplication
         }
 
         return $applications;
+    }
+
+    /**
+     * Get a single application by name.
+     *
+     * @param string|null $name
+     *     The application name.
+     * @param string $directory
+     *     The absolute path to a directory.
+     * @param CliConfig|null $config
+     *     CLI configuration.
+     *
+     * @return LocalApplication
+     */
+    public static function getApplication($name, $directory, CliConfig $config = null)
+    {
+        $apps = self::getApplications($directory, $config);
+        if ($name === null && count($apps) === 1) {
+            return reset($apps);
+        }
+        foreach ($apps as $app) {
+            if ($app->getName() === $name) {
+                return $app;
+            }
+        }
+
+        throw new \InvalidArgumentException('App not found: ' . $name);
     }
 
     /**

--- a/src/Util/RelationshipsUtil.php
+++ b/src/Util/RelationshipsUtil.php
@@ -54,14 +54,6 @@ class RelationshipsUtil
             return false;
         }
 
-        // If there is a single choice, return it early.
-        if (count($relationships) === 1) {
-            $relationship = reset($relationships);
-            if (count($relationship) === 1) {
-                return reset($relationship);
-            }
-        }
-
         $questionHelper = new QuestionHelper($input, $this->output);
         $choices = [];
         $separator = '.';
@@ -74,6 +66,10 @@ class RelationshipsUtil
         $choice = $questionHelper->choose($choices, 'Enter a number to choose a database:');
         list($name, $key) = explode($separator, $choice, 2);
         $database = $relationships[$name][$key];
+
+        // Add metadata about the database.
+        $database['_relationship_name'] = $name;
+        $database['_relationship_key'] = $key;
 
         return $database;
     }


### PR DESCRIPTION
The `EnvironmentSqlSizeCommand` class is a little bit dirty, especially as it does not return the same data for MySQL and PostgreSQL.

I guessed two types of reports were sufficiant for the time being: Overview and Details. Detailed reports can be requested with `--details` option.

Out of the box, MySQL allows XML responses, so I added a `--xml` option for that. 

Review would be more than appreciated.

Thanks,
Branislav