### PR TITLE
Add unix shell as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The **Platform.sh CLI** is the official command-line interface for [Platform.sh]
 ## Requirements
 
 * Operating system: Linux, OS X, Windows Vista, Windows 7, Windows 8 Pro, or Windows 10 (Windows 8 Standard does not work due to an issue with symlink permissions)
+* Linux/Unix compatible shell
 * PHP 5.5.9 or higher, with cURL support
 * Git
 * For building locally, your project's dependencies, e.g.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ The **Platform.sh CLI** is the official command-line interface for [Platform.sh]
 ## Requirements
 
 * Operating system: Linux, OS X, Windows Vista, Windows 7, Windows 8 Pro, or Windows 10 (Windows 8 Standard does not work due to an issue with symlink permissions)
-* Linux/Unix compatible shell
 * PHP 5.5.9 or higher, with cURL support
 * Git
+* A Bash-like shell:
+  * On OS X or Linux/Unix: SH, Bash, Dash or ZSH - usually the built-in shell will work.
+  * On Windows: [Bash on Ubuntu](https://msdn.microsoft.com/en-gb/commandline/wsl/about) on Windows (recommended), or a Bash-compatible shell such as [Git Bash](https://git-for-windows.github.io/), Cygwin, or MinGW.
 * For building locally, your project's dependencies, e.g.
   * [Composer](https://getcomposer.org/) (for many PHP projects)
   * [Drush](https://github.com/drush-ops/drush) (for Drupal projects)


### PR DESCRIPTION
Unless PowerShell is supported, we better let user know we need linux/unix shell.