### PR TITLE
Document setting environment variables.

### DIFF
--- a/src/Command/Project/Variable/ProjectVariableSetCommand.php
+++ b/src/Command/Project/Variable/ProjectVariableSetCommand.php
@@ -30,6 +30,7 @@ class ProjectVariableSetCommand extends CommandBase
         $this->addExample('Set the variable "example" to the Boolean TRUE', 'example --json true');
         $this->addExample('Set the variable "example" to a list of values', 'example --json \'["value1", "value2"]\'');
         $this->addExample('Set the variable "example" to the string "abc", but only at build time', 'example abc --no-visible-runtime');
+        $this->addExample('Set the variable "EXAMPLE" outside of the PLATFORM_VARIABLES to the string "abc" by prefixing the variable name with "env:"', 'env:EXAMPLE abc');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
I had troubles finding documentation for custom environment variables (https://docs.platform.sh/development/environment-variables.html#custom-environment-variables), so I thought adding an example with `env:` prefix would make sense. 