### PR TITLE
Clarify that self-update output messages are about platform.sh CLI

### DIFF
--- a/src/Service/SelfUpdater.php
+++ b/src/Service/SelfUpdater.php
@@ -86,8 +86,12 @@ class SelfUpdater
     {
         $currentVersion = $currentVersion ?: $this->config->get('application.version');
         $manifestUrl = $manifestUrl ?: $this->config->get('application.manifest_url');
+        $applicationName = $this->config->get('application.name');
         if (!extension_loaded('Phar') || !($localPhar = \Phar::running(false))) {
-            $this->stdErr->writeln('This instance of the platform.sh CLI was not installed as a Phar archive.');
+            $this->stdErr->writeln(sprintf(
+                'This instance of the %s was not installed as a Phar archive.',
+                $applicationName
+            ));
 
             // Instructions for users who are running a global Composer install.
             if (defined('CLI_ROOT') && file_exists(CLI_ROOT . '/../../autoload.php')) {
@@ -99,7 +103,11 @@ class SelfUpdater
             return false;
         }
 
-        $this->stdErr->writeln(sprintf('Checking for platform.sh CLI updates (current version: <info>%s</info>)', $currentVersion));
+        $this->stdErr->writeln(sprintf(
+            'Checking for %s updates (current version: <info>%s</info>)',
+            $applicationName,
+            $currentVersion
+        ));
 
         $updater = new Updater(null, false);
         $strategy = new ManifestStrategy($currentVersion, $manifestUrl, $this->allowMajor, $this->allowUnstable);
@@ -128,7 +136,11 @@ class SelfUpdater
 
         $updater->update();
 
-        $this->stdErr->writeln("Successfully updated platform.sh CLI to version <info>$newVersionString</info>");
+        $this->stdErr->writeln(sprintf(
+            'The %s has been successfully updated to version <info>%s</info>',
+            $applicationName,
+            $newVersionString
+        ));
 
         return $newVersionString;
     }

--- a/src/Service/SelfUpdater.php
+++ b/src/Service/SelfUpdater.php
@@ -87,7 +87,7 @@ class SelfUpdater
         $currentVersion = $currentVersion ?: $this->config->get('application.version');
         $manifestUrl = $manifestUrl ?: $this->config->get('application.manifest_url');
         if (!extension_loaded('Phar') || !($localPhar = \Phar::running(false))) {
-            $this->stdErr->writeln('This instance of the CLI was not installed as a Phar archive.');
+            $this->stdErr->writeln('This instance of the platform.sh CLI was not installed as a Phar archive.');
 
             // Instructions for users who are running a global Composer install.
             if (defined('CLI_ROOT') && file_exists(CLI_ROOT . '/../../autoload.php')) {
@@ -99,7 +99,7 @@ class SelfUpdater
             return false;
         }
 
-        $this->stdErr->writeln(sprintf('Checking for updates (current version: <info>%s</info>)', $currentVersion));
+        $this->stdErr->writeln(sprintf('Checking for platform.sh CLI updates (current version: <info>%s</info>)', $currentVersion));
 
         $updater = new Updater(null, false);
         $strategy = new ManifestStrategy($currentVersion, $manifestUrl, $this->allowMajor, $this->allowUnstable);
@@ -128,7 +128,7 @@ class SelfUpdater
 
         $updater->update();
 
-        $this->stdErr->writeln("Successfully updated to version <info>$newVersionString</info>");
+        $this->stdErr->writeln("Successfully updated platform.sh CLI to version <info>$newVersionString</info>");
 
         return $newVersionString;
     }


### PR DESCRIPTION
Platform.sh CLI occasionally checks for updates, even when `platform self:update` is not the command being run.

If the CLI is called from a custom script, then it isn't always clear that the message is about updating the platform.sh CLI tool.

Example:
We use [Docksal](http://docksal.io/) `fin` custom commands for for tasks such as dumping a DB from a platform.sh environment, and importing it into the local Docksal database container. It's a little bit confusing to type a `fin db-download master` command and see a message about checking for updates - is it updating `fin` or updating `platform`?

This PR adds the name "platform.sh CLI" to some of the SelfUpdate output messages:

 - At the start of the output ("This instance of the platform.sh CLI ..." and "Checking for platform.sh CLI updates..."), and
 - At the end of the output, if the update actually took place ("Successfully updated platform.sh CLI...").

All these messages are still less than 75 characters, so will likely fit on one line.