### PR TITLE
Add an option to install dependencies globally

### DIFF
--- a/src/Command/Local/LocalBuildCommand.php
+++ b/src/Command/Local/LocalBuildCommand.php
@@ -93,6 +93,12 @@ class LocalBuildCommand extends CommandBase
                 'Do not install build dependencies locally'
             )
             ->addOption(
+                'global-deps',
+                null,
+                InputOption::VALUE_NONE,
+                'Install build dependencies globally (user or system-wide)'
+            )
+            ->addOption(
                 'working-copy',
                 null,
                 InputOption::VALUE_NONE,

--- a/src/Local/DependencyInstaller.php
+++ b/src/Local/DependencyInstaller.php
@@ -56,14 +56,14 @@ class DependencyInstaller
             $this->output->writeln(sprintf(
                 "Installing <info>%s</info> dependencies with '%s': %s",
                 $stack,
-                $manager->getCommandName($global),
+                $manager->getCommandName(),
                 implode(', ', array_keys($stackDependencies))
             ));
             if (!$manager->isAvailable()) {
                 throw new \RuntimeException(rtrim(sprintf(
                     "Cannot install %s dependencies: '%s' is not installed\n%s",
                     $stack,
-                    $manager->getCommandName($global),
+                    $manager->getCommandName(),
                     $manager->getInstallHelp()
                 )));
             }
@@ -91,7 +91,7 @@ class DependencyInstaller
     protected function getManager($name)
     {
         $stacks = [
-            'nodejs' => new DependencyManager\Yarn($this->shell),
+            'nodejs' => new DependencyManager\Npm($this->shell),
             'python' => new DependencyManager\Pip($this->shell),
             'ruby' => new DependencyManager\Bundler($this->shell),
             'php' => new DependencyManager\Composer($this->shell),

--- a/src/Local/DependencyInstaller.php
+++ b/src/Local/DependencyInstaller.php
@@ -46,29 +46,30 @@ class DependencyInstaller
 
     /**
      * @param string $destination
-     * @param array $dependencies
+     * @param array  $dependencies
+     * @param bool   $global
      */
-    public function installDependencies($destination, array $dependencies)
+    public function installDependencies($destination, array $dependencies, $global = false)
     {
         foreach ($dependencies as $stack => $stackDependencies) {
             $manager = $this->getManager($stack);
             $this->output->writeln(sprintf(
                 "Installing <info>%s</info> dependencies with '%s': %s",
                 $stack,
-                $manager->getCommandName(),
+                $manager->getCommandName($global),
                 implode(', ', array_keys($stackDependencies))
             ));
             if (!$manager->isAvailable()) {
                 throw new \RuntimeException(rtrim(sprintf(
                     "Cannot install %s dependencies: '%s' is not installed\n%s",
                     $stack,
-                    $manager->getCommandName(),
+                    $manager->getCommandName($global),
                     $manager->getInstallHelp()
                 )));
             }
             $path = $destination . '/' . $stack;
             $this->ensureDirectory($path);
-            $manager->install($path, $stackDependencies);
+            $manager->install($path, $stackDependencies, $global);
         }
     }
 

--- a/src/Local/DependencyManager/Bundler.php
+++ b/src/Local/DependencyManager/Bundler.php
@@ -25,7 +25,7 @@ class Bundler extends DependencyManagerBase
     /**
      * {@inheritdoc}
      */
-    public function install($path, array $dependencies)
+    public function install($path, array $dependencies, $global = false)
     {
         $gemFile = $path . '/Gemfile';
         $gemFileContent = $this->formatGemfile($dependencies);
@@ -36,7 +36,11 @@ class Bundler extends DependencyManagerBase
                 unlink('Gemfile.lock');
             }
         }
-        $this->runCommand('bundler install --path=. --binstubs', $path);
+        if ($global) {
+            $this->runCommand('bundle install --system --gemfile=Gemfile', $path);
+        } else {
+            $this->runCommand('bundle install --path=. --binstubs --gemfile=Gemfile', $path);
+        }
     }
 
     /**

--- a/src/Local/DependencyManager/Composer.php
+++ b/src/Local/DependencyManager/Composer.php
@@ -25,8 +25,12 @@ class Composer extends DependencyManagerBase
     /**
      * {@inheritdoc}
      */
-    public function install($path, array $dependencies)
+    public function install($path, array $dependencies, $global = false)
     {
+        if ($global) {
+            $this->installGlobal($dependencies);
+            return;
+        }
         $composerJson = $path . '/composer.json';
         $contents = file_exists($composerJson) ? file_get_contents($composerJson) : null;
         $newContents = json_encode(['require' => $dependencies]);
@@ -36,6 +40,25 @@ class Composer extends DependencyManagerBase
                 unlink($path . '/composer.lock');
             }
         }
+
         $this->runCommand('composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction', $path);
+    }
+
+    /**
+     * Install dependencies globally.
+     *
+     * @param array $dependencies
+     */
+    private function installGlobal(array $dependencies)
+    {
+        $requirements = [];
+        foreach ($dependencies as $package => $version) {
+            $requirements[] = $version === '*' ? $package : $package . ':' . $version;
+        }
+        $this->runCommand(
+            'composer global require '
+            . '--no-progress --prefer-dist --optimize-autoloader --no-interaction '
+            . implode(' ', array_map('escapeshellarg', $requirements))
+        );
     }
 }

--- a/src/Local/DependencyManager/DependencyManagerBase.php
+++ b/src/Local/DependencyManager/DependencyManagerBase.php
@@ -16,7 +16,7 @@ abstract class DependencyManagerBase implements DependencyManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getCommandName()
+    public function getCommandName($global = false)
     {
         return $this->command;
     }
@@ -38,10 +38,10 @@ abstract class DependencyManagerBase implements DependencyManagerInterface
     }
 
     /**
-     * @param string $command
-     * @param string $path
+     * @param string      $command
+     * @param string|null $path
      */
-    protected function runCommand($command, $path)
+    protected function runCommand($command, $path = null)
     {
         $code = $this->shell->executeSimple($command, $path);
         if ($code > 0) {

--- a/src/Local/DependencyManager/DependencyManagerInterface.php
+++ b/src/Local/DependencyManager/DependencyManagerInterface.php
@@ -4,36 +4,55 @@ namespace Platformsh\Cli\Local\DependencyManager;
 interface DependencyManagerInterface
 {
     /**
+     * Returns the command name of the dependency manager to be used.
+     *
+     * @param bool $global Whether the install is going to be global to the user
+     *                     or system.
+     *
      * @return string
      */
-    public function getCommandName();
+    public function getCommandName($global = false);
 
     /**
+     * Checks whether the dependency manager itself is available (installed).
+     *
      * @return bool
      */
     public function isAvailable();
 
     /**
+     * Returns help for the user to install the dependency manager itself.
+     *
      * @return string
      */
     public function getInstallHelp();
 
     /**
-     * @param string $path The path prefix for the dependencies.
+     * Installs a list of dependencies.
      *
+     * @param string $path        A path in which dependencies can be installed,
+     *                            or (if $global is true) a path for running
+     *                            commands and writing config files.
      * @param array $dependencies An associative array of dependencies with
      *                            their versions.
+     * @param bool $global        Whether to install dependencies globally for
+     *                            the user or system (i.e. not attached to the
+     *                            project).
      */
-    public function install($path, array $dependencies);
+    public function install($path, array $dependencies, $global = false);
 
     /**
+     * Returns a list of "bin" directories in which dependencies are installed.
+     *
      * @param string $path The path prefix for the dependencies.
      *
-     * @return array An array of absolute paths to "bin" directories.
+     * @return array An array of absolute paths.
      */
     public function getBinPaths($path);
 
     /**
+     * Returns a list of environment variables for using installed dependencies.
+     *
      * @param string $path The path prefix for the dependencies.
      *
      * @return array An associative array of environment variables.

--- a/src/Local/DependencyManager/DependencyManagerInterface.php
+++ b/src/Local/DependencyManager/DependencyManagerInterface.php
@@ -6,12 +6,9 @@ interface DependencyManagerInterface
     /**
      * Returns the command name of the dependency manager to be used.
      *
-     * @param bool $global Whether the install is going to be global to the user
-     *                     or system.
-     *
      * @return string
      */
-    public function getCommandName($global = false);
+    public function getCommandName();
 
     /**
      * Checks whether the dependency manager itself is available (installed).

--- a/src/Local/DependencyManager/Pip.php
+++ b/src/Local/DependencyManager/Pip.php
@@ -25,10 +25,14 @@ class Pip extends DependencyManagerBase
     /**
      * {@inheritdoc}
      */
-    public function install($path, array $dependencies)
+    public function install($path, array $dependencies, $global = false)
     {
         file_put_contents($path . '/requirements.txt', $this->formatRequirementsTxt($dependencies));
-        $this->runCommand('pip install --requirement=requirements.txt --prefix=.', $path);
+        $command = 'pip install --requirement=requirements.txt';
+        if (!$global) {
+            $command .= ' --prefix=.';
+        }
+        $this->runCommand($command, $path);
     }
 
     /**

--- a/src/Local/DependencyManager/Yarn.php
+++ b/src/Local/DependencyManager/Yarn.php
@@ -4,6 +4,8 @@ namespace Platformsh\Cli\Local\DependencyManager;
 
 class Yarn extends DependencyManagerBase
 {
+    protected $globalList;
+
     /**
      * {@inheritdoc}
      */
@@ -15,9 +17,9 @@ class Yarn extends DependencyManagerBase
     /**
      * {@inheritdoc}
      */
-    public function getCommandName()
+    public function getCommandName($global = false)
     {
-        return $this->shell->commandExists('yarn') ? 'yarn' : 'npm';
+        return !$global && $this->shell->commandExists('yarn') ? 'yarn' : 'npm';
     }
 
     /**
@@ -39,8 +41,12 @@ class Yarn extends DependencyManagerBase
     /**
      * {@inheritdoc}
      */
-    public function install($path, array $dependencies)
+    public function install($path, array $dependencies, $global = false)
     {
+        if ($global) {
+            $this->installGlobal($dependencies);
+            return;
+        }
         $packageJsonFile = $path . '/package.json';
         $packageJson = json_encode([
             'name' => 'temporary-build-dependencies',
@@ -60,5 +66,40 @@ class Yarn extends DependencyManagerBase
         } else {
             $this->runCommand('npm install --global-style', $path);
         }
+    }
+
+    /**
+     * Install dependencies globally.
+     *
+     * @param array $dependencies
+     */
+    private function installGlobal(array $dependencies)
+    {
+        foreach ($dependencies as $package => $version) {
+            if ($this->isInstalledGlobally($package, $version)) {
+                continue;
+            }
+            $arg = escapeshellarg($version === '*' ? $package : $package . ':' . $version);
+            $command = 'npm install --global ' . $arg;
+            $this->runCommand($command);
+        }
+    }
+
+    /**
+     * @param string $package
+     * @param string $version
+     *
+     * @return bool
+     */
+    private function isInstalledGlobally($package, $version)
+    {
+        if (!isset($this->globalList)) {
+            $this->globalList = $this->shell->execute(
+                ['npm', 'ls', '--global', '--no-progress', '--depth=0']
+            );
+        }
+        $needle = $version === '*' ? $package : $package . '@' . $version;
+
+        return $this->globalList && strpos($this->globalList, $needle) !== false;
     }
 }

--- a/src/Local/LocalBuild.php
+++ b/src/Local/LocalBuild.php
@@ -298,7 +298,8 @@ class LocalBuild
                 } else {
                     $this->dependencyInstaller->installDependencies(
                         $depsDir,
-                        $appConfig['dependencies']
+                        $appConfig['dependencies'],
+                        !empty($this->settings['global-deps'])
                     );
                 }
 


### PR DESCRIPTION
This isn't the default, because many package managers just can't cope properly with global/system-wide installs, e.g. Composer.