### PR TITLE
Add a command to view a resolved route of an environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ environment
   environment:merge (merge)                 Merge an environment
   environment:push (push)                   Push code to an environment
   environment:relationships (relationships)   Show an environment's relationships
+  environment:route:get (route-get)         View a route
   environment:routes (routes)               List an environment's routes
   environment:ssh (ssh)                     SSH to the current environment
   environment:synchronize (sync)            Synchronize an environment's code and/or data from its parent

--- a/services.yaml
+++ b/services.yaml
@@ -42,6 +42,9 @@ services:
     relationships:
         class:     '\Platformsh\Cli\Service\Relationships'
         arguments: ['@output', '@ssh', '@cache', '@shell', '@config']
+    routes:
+        class:     '\Platformsh\Cli\Service\Routes'
+        arguments: ['@ssh', '@cache', '@shell', '@config']
     self_updater:
         class:     '\Platformsh\Cli\Service\SelfUpdater'
         arguments: ['@input', '@output', '@config', '@question_helper']

--- a/src/Application.php
+++ b/src/Application.php
@@ -120,6 +120,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Environment\EnvironmentSynchronizeCommand();
         $commands[] = new Command\Environment\EnvironmentUrlCommand();
         $commands[] = new Command\Environment\EnvironmentSetRemoteCommand();
+        $commands[] = new Command\Environment\Route\RouteGetCommand();
         $commands[] = new Command\Integration\IntegrationAddCommand();
         $commands[] = new Command\Integration\IntegrationDeleteCommand();
         $commands[] = new Command\Integration\IntegrationGetCommand();

--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -161,9 +161,10 @@ class EnvironmentPushCommand extends CommandBase
         if ($this->hasSelectedEnvironment()) {
             try {
                 $sshUrl = $this->getSelectedEnvironment()->getSshUrl();
-                /** @var \Platformsh\Cli\Service\Relationships $relationships */
-                $relationships = $this->getService('relationships');
-                $relationships->clearCache($sshUrl);
+                /** @var \Doctrine\Common\Cache\CacheProvider $cache */
+                $cache = $this->getService('cache');
+                $cache->delete('relationships-' . $sshUrl);
+                $cache->delete('routes-' . $sshUrl);
             } catch (EnvironmentStateException $e) {
                 // Ignore environments with a missing SSH URL.
             }

--- a/src/Command/Environment/EnvironmentRoutesCommand.php
+++ b/src/Command/Environment/EnvironmentRoutesCommand.php
@@ -2,6 +2,7 @@
 namespace Platformsh\Cli\Command\Environment;
 
 use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Service\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,15 +41,13 @@ class EnvironmentRoutesCommand extends CommandBase
         /** @var \Platformsh\Cli\Service\Table $table */
         $table = $this->getService('table');
 
-        $header = ['Route', 'Type', 'To', 'Cache', 'SSI'];
+        $header = ['Route', 'Type', 'To'];
         $rows = [];
         foreach ($routes as $route) {
             $rows[] = [
-                $route->id,
+                new AdaptiveTableCell($route->id, ['wrap' => false]),
                 $route->type,
                 $route->type == 'upstream' ? $route->upstream : $route->to,
-                json_encode($route->cache),
-                json_encode($route->ssi),
             ];
         }
 
@@ -57,6 +56,14 @@ class EnvironmentRoutesCommand extends CommandBase
         }
 
         $table->render($rows, $header);
+
+        if (!$table->formatIsMachineReadable()) {
+            $this->stdErr->writeln('');
+            $this->stdErr->writeln(sprintf(
+                'To view a single route, run: <info>%s route-get <route></info>',
+                $this->config()->get('application.executable')
+            ));
+        }
 
         return 0;
     }

--- a/src/Command/Environment/Route/RouteGetCommand.php
+++ b/src/Command/Environment/Route/RouteGetCommand.php
@@ -1,0 +1,82 @@
+<?php
+namespace Platformsh\Cli\Command\Environment\Route;
+
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Service\PropertyFormatter;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RouteGetCommand extends CommandBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('environment:route:get')
+            ->setAliases(['route-get'])
+            ->setDescription('View a route')
+            ->addArgument('route', InputArgument::OPTIONAL, "The route's original URL")
+            ->addOption('property', 'P', InputOption::VALUE_REQUIRED, 'The property to display')
+            ->addOption('refresh', null, InputOption::VALUE_NONE, 'Bypass the cache of routes');
+        PropertyFormatter::configureInput($this->getDefinition());
+        $this->addProjectOption()
+            ->addEnvironmentOption()
+            ->addAppOption();
+        $this->addExample('View the URL to the https://{default}/ route', "'https://{default}/' -P url");
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->validateInput($input);
+
+        $environment = $this->getSelectedEnvironment();
+
+        $sshUrl = $environment->getSshUrl($this->selectApp($input));
+
+        /** @var \Platformsh\Cli\Service\Routes $routesService */
+        $routesService = $this->getService('routes');
+        $routes = $routesService->getRoutes($sshUrl, $input->getOption('refresh'));
+
+        $selectedRoute = false;
+        $originalUrl = $input->getArgument('route');
+        if ($originalUrl === null) {
+            if (!$input->isInteractive()) {
+                $this->stdErr->writeln('The <comment>route</comment> argument is required.');
+
+                return 1;
+            }
+            /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+            $questionHelper = $this->getService('question_helper');
+            $items = [];
+            foreach ($routes as $route) {
+                $items[$route['original_url']] = $route['original_url'];
+            }
+            $originalUrl = $questionHelper->choose($items, 'Enter a number to choose a route:');
+        }
+
+        foreach ($routes as $url => $route) {
+            if ($route['original_url'] === $originalUrl) {
+                $selectedRoute = $route;
+                $selectedRoute['url'] = $url;
+                break;
+            }
+        }
+
+        if (!$selectedRoute) {
+            $this->stdErr->writeln(sprintf('Route not found: <comment>%s</comment>', $originalUrl));
+
+            return 1;
+        }
+
+        /** @var PropertyFormatter $propertyFormatter */
+        $propertyFormatter = $this->getService('property_formatter');
+
+        $propertyFormatter->displayData($output, $selectedRoute, $input->getOption('property'));
+
+        return 0;
+    }
+}

--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -118,9 +118,7 @@ class Relationships implements InputConfiguringInterface
         $relationships = $this->cache->fetch($cacheKey);
         if ($refresh || $relationships === false) {
             $args = ['ssh'];
-            if (isset($this->ssh)) {
-                $args = array_merge($args, $this->ssh->getSshArgs());
-            }
+            $args = array_merge($args, $this->ssh->getSshArgs());
             $args[] = $sshUrl;
             $args[] = 'echo $' . $this->config->get('service.env_prefix') . 'RELATIONSHIPS';
             $result = $this->shellHelper->execute($args, null, true);
@@ -129,16 +127,6 @@ class Relationships implements InputConfiguringInterface
         }
 
         return $relationships;
-    }
-
-    /**
-     * Clear the cache.
-     *
-     * @param string $sshUrl
-     */
-    public function clearCache($sshUrl)
-    {
-        $this->cache->delete('relationships-' . $sshUrl);
     }
 
     /**

--- a/src/Service/Routes.php
+++ b/src/Service/Routes.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Platformsh\Cli\Service;
+
+use Doctrine\Common\Cache\CacheProvider;
+
+class Routes
+{
+
+    protected $shellHelper;
+    protected $config;
+    protected $ssh;
+    protected $cache;
+
+    /**
+     * @param Ssh             $ssh
+     * @param CacheProvider   $cache
+     * @param Shell           $shellHelper
+     * @param Config          $config
+     */
+    public function __construct(
+        Ssh $ssh,
+        CacheProvider $cache,
+        Shell $shellHelper,
+        Config $config
+    ) {
+        $this->ssh = $ssh;
+        $this->cache = $cache;
+        $this->shellHelper = $shellHelper;
+        $this->config = $config;
+    }
+
+    /**
+     * @param string $sshUrl
+     * @param bool   $refresh
+     *
+     * @return array
+     */
+    public function getRoutes($sshUrl, $refresh = false)
+    {
+        $cacheKey = 'routes-' . $sshUrl;
+        $routes = $this->cache->fetch($cacheKey);
+        if ($refresh || $routes === false) {
+            $args = ['ssh'];
+            $args = array_merge($args, $this->ssh->getSshArgs());
+            $args[] = $sshUrl;
+            $args[] = 'echo $' . $this->config->get('service.env_prefix') . 'ROUTES';
+            $result = $this->shellHelper->execute($args, null, true);
+            $routes = json_decode(base64_decode($result), true);
+            $this->cache->save($cacheKey, $routes, 3600);
+        }
+
+        return $routes;
+    }
+}


### PR DESCRIPTION
```
$ platform environment:route:get
Enter a number to choose a route:
  [0] https://{default}/
  [1] http://{default}/
  [2] http://www.{default}/
  [3] https://www.{default}/
 > 0
ssi:
    enabled: false
original_url: 'https://{default}/'
upstream: php
cache:
    default_ttl: 0
    cookies:
        - '*'
    enabled: true
    headers:
        - Accept
        - Accept-Language
type: upstream
url: 'https://my-branch-vgdzl2y-abcdef123456.eu.platform.sh/'
```