### PR TITLE
Rely on date_default_timezone_get() instead of UTC fallback

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -243,7 +243,8 @@ class Application extends ParentApplication
      */
     protected function setDefaultTimezone()
     {
-        $timezone = 'UTC';
+        $timezone = date_default_timezone_get();
+
         if (is_link('/etc/localtime')) {
             // Mac OS X (and older Linuxes)
             // /etc/localtime is a symlink to the timezone in /usr/share/zoneinfo.

--- a/src/Application.php
+++ b/src/Application.php
@@ -235,11 +235,10 @@ class Application extends ParentApplication
     }
 
     /**
-     * Set the default timezone.
+     * Set the default PHP timezone according to the system timezone.
      *
-     * PHP 5.4 has removed the autodetection of the system timezone,
-     * so it needs to be done manually.
-     * UTC is the fallback in case autodetection fails.
+     * PHP >=5.4 removed the autodetection of the system timezone, so it is
+     * re-implemented here.
      */
     protected function setDefaultTimezone()
     {


### PR DESCRIPTION
PHP should be aware of the current timezone, so fallback to UTC would be implicit by using `date_default_timezone_get()`, because if `date.timezone` is not set in `php.ini`, default one is UTC.