### PR TITLE
Close pipes before closing proc

### DIFF
--- a/src/Service/Shell.php
+++ b/src/Service/Shell.php
@@ -66,6 +66,7 @@ class Shell
         $this->showWorkingDirMessage($dir);
 
         $process = proc_open($commandline, [STDIN, STDOUT, STDERR], $pipes, $dir, $env);
+        array_walk($pipes, 'fclose');
 
         return proc_close($process);
     }


### PR DESCRIPTION
As stated in http://php.net/proc_open all pipes must be closed, before closing the process to prevent any memory leaks.