### PR TITLE
Fix infinite loop in Config::canWriteDir

### DIFF
--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -101,6 +101,7 @@ class Config
             if (is_writable($parent)) {
                 return true;
             }
+            $current = $parent;
         }
 
         return false;


### PR DESCRIPTION
When the `HOME` directory is not writable (e.g. on our environments), we end up spinning in the loop in `Config::canWriteDir` because of the failure to set `$current`.