### PR TITLE
Respect date.timezone and allow TZ env var

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -3,6 +3,7 @@ namespace Platformsh\Cli;
 
 use Platformsh\Cli\Console\EventSubscriber;
 use Platformsh\Cli\Service\Config;
+use Platformsh\Cli\Util\TimezoneUtil;
 use Symfony\Component\Console\Application as ParentApplication;
 use Symfony\Component\Console\Command\Command as ConsoleCommand;
 use Symfony\Component\Console\Exception\InvalidArgumentException as ConsoleInvalidArgumentException;
@@ -34,7 +35,7 @@ class Application extends ParentApplication
         $this->cliConfig = new Config();
         parent::__construct($this->cliConfig->get('application.name'), $this->cliConfig->get('application.version'));
 
-        $this->setDefaultTimezone();
+        date_default_timezone_set(TimezoneUtil::getTimezone());
 
         $this->addCommands($this->getCommands());
 
@@ -258,40 +259,6 @@ class Application extends ParentApplication
         // The parent class has a similar (private) property named
         // $runningCommand.
         $this->currentCommand = $command;
-    }
-
-    /**
-     * Set the default PHP timezone according to the system timezone.
-     *
-     * PHP >=5.4 removed the autodetection of the system timezone, so it is
-     * re-implemented here.
-     */
-    protected function setDefaultTimezone()
-    {
-        $timezone = date_default_timezone_get();
-
-        if (is_link('/etc/localtime')) {
-            // Mac OS X (and older Linuxes)
-            // /etc/localtime is a symlink to the timezone in /usr/share/zoneinfo.
-            $filename = readlink('/etc/localtime');
-            if (strpos($filename, '/usr/share/zoneinfo/') === 0) {
-                $timezone = substr($filename, 20);
-            }
-        } elseif (file_exists('/etc/timezone')) {
-            // Ubuntu / Debian.
-            $data = file_get_contents('/etc/timezone');
-            if ($data) {
-                $timezone = trim($data);
-            }
-        } elseif (file_exists('/etc/sysconfig/clock')) {
-            // RHEL/CentOS
-            $data = parse_ini_file('/etc/sysconfig/clock');
-            if (!empty($data['ZONE'])) {
-                $timezone = trim($data['ZONE']);
-            }
-        }
-
-        date_default_timezone_set($timezone);
     }
 
     /**

--- a/src/Command/Activity/ActivityListCommand.php
+++ b/src/Command/Activity/ActivityListCommand.php
@@ -4,6 +4,7 @@ namespace Platformsh\Cli\Command\Activity;
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Service\ActivityMonitor;
+use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,6 +28,7 @@ class ActivityListCommand extends CommandBase
             ->addOption('all', 'a', InputOption::VALUE_NONE, 'Check activities on all environments')
             ->setDescription('Get a list of activities for an environment or project');
         Table::configureInput($this->getDefinition());
+        PropertyFormatter::configureInput($this->getDefinition());
         $this->addProjectOption()
              ->addEnvironmentOption();
         $this->addExample('List recent activities for the current environment')
@@ -87,12 +89,14 @@ class ActivityListCommand extends CommandBase
 
         /** @var \Platformsh\Cli\Service\Table $table */
         $table = $this->getService('table');
+        /** @var \Platformsh\Cli\Service\PropertyFormatter $formatter */
+        $formatter = $this->getService('property_formatter');
 
         $rows = [];
         foreach ($activities as $activity) {
             $row = [
                 new AdaptiveTableCell($activity->id, ['wrap' => false]),
-                date('Y-m-d H:i:s', strtotime($activity['created_at'])),
+                $formatter->format($activity['created_at'], 'created_at'),
                 $activity->getDescription(),
                 $activity->getCompletionPercent() . '%',
                 ActivityMonitor::formatState($activity->state),

--- a/src/Command/Snapshot/SnapshotListCommand.php
+++ b/src/Command/Snapshot/SnapshotListCommand.php
@@ -4,6 +4,7 @@ namespace Platformsh\Cli\Command\Snapshot;
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Service\ActivityMonitor;
+use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -21,6 +22,7 @@ class SnapshotListCommand extends CommandBase
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of snapshots to list', 10)
             ->addOption('start', null, InputOption::VALUE_REQUIRED, 'Only snapshots created before this date will be listed');
         Table::configureInput($this->getDefinition());
+        PropertyFormatter::configureInput($this->getDefinition());
         $this->addProjectOption()
              ->addEnvironmentOption();
         $this->addExample('List the most recent snapshots')
@@ -41,6 +43,8 @@ class SnapshotListCommand extends CommandBase
 
         /** @var \Platformsh\Cli\Service\Table $table */
         $table = $this->getService('table');
+        /** @var \Platformsh\Cli\Service\PropertyFormatter $formatter */
+        $formatter = $this->getService('property_formatter');
 
         if (!$table->formatIsMachineReadable()) {
             $this->stdErr->writeln("Finding snapshots for the environment <info>{$environment->id}</info>");
@@ -57,7 +61,7 @@ class SnapshotListCommand extends CommandBase
         foreach ($activities as $activity) {
             $snapshot_name = !empty($activity->payload['backup_name']) ? $activity->payload['backup_name'] : 'N/A';
             $rows[] = [
-                date('Y-m-d H:i:s', strtotime($activity->created_at)),
+                $formatter->format($activity->created_at, 'created_at'),
                 new AdaptiveTableCell($snapshot_name, ['wrap' => false]),
                 $activity->getCompletionPercent() . '%',
                 ActivityMonitor::formatState($activity->state),

--- a/src/Command/Snapshot/SnapshotRestoreCommand.php
+++ b/src/Command/Snapshot/SnapshotRestoreCommand.php
@@ -75,7 +75,7 @@ class SnapshotRestoreCommand extends CommandBase
         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
         $questionHelper = $this->getService('question_helper');
         $name = $selectedActivity['payload']['backup_name'];
-        $date = date('Y-m-d H:i', strtotime($selectedActivity['created_at']));
+        $date = date('c', strtotime($selectedActivity['created_at']));
         if (!$questionHelper->confirm(
             "Are you sure you want to restore the snapshot <comment>$name</comment> from <comment>$date</comment>?"
         )) {

--- a/src/Util/TimezoneUtil.php
+++ b/src/Util/TimezoneUtil.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Platformsh\Cli\Util;
+
+class TimezoneUtil
+{
+    /**
+     * Get the timezone intended by the user.
+     *
+     * The timezone is detected with the following priorities:
+     *
+     * 1. A value previously set via date_default_timezone_set(), which can
+     *    only be known if it is not the default, UTC.
+     * 2. The value of the ini setting 'date.timezone'.
+     * 3. The value of the TZ environment variable, if set.
+     * 4. A best guess at the system timezone: see self::detectSystemTimezone().
+     * 5. Default to the value of date_default_timezone_get(), which at this
+     *    stage will almost definitely be UTC.
+     *
+     * @return string
+     */
+    public static function getTimezone()
+    {
+        $currentTz = date_default_timezone_get();
+        if ($currentTz !== 'UTC') {
+            return $currentTz;
+        }
+
+        if (ini_get('date.timezone')) {
+            return ini_get('date.timezone');
+        }
+
+        if (getenv('TZ')) {
+            return (string) getenv('TZ');
+        }
+
+        if ($systemTz = self::detectSystemTimezone()) {
+            return $systemTz;
+        }
+
+        return $currentTz;
+    }
+
+    /**
+     * Detect the system timezone, restoring functionality from PHP < 5.4.
+     *
+     * @return string|false
+     */
+    private static function detectSystemTimezone()
+    {
+        // Mac OS X (and older Linuxes): /etc/localtime is a symlink to the
+        // timezone in /usr/share/zoneinfo or /var/db/timezone/zoneinfo.
+        if (is_link('/etc/localtime')) {
+            $filename = readlink('/etc/localtime');
+            $prefixes = [
+                '/usr/share/zoneinfo/',
+                '/var/db/timezone/zoneinfo/',
+            ];
+            foreach ($prefixes as $prefix) {
+                if (strpos($filename, $prefix) === 0) {
+                    return substr($filename, strlen($prefix));
+                }
+            }
+        }
+
+        // Ubuntu and Debian.
+        if (file_exists('/etc/timezone')) {
+            $data = file_get_contents('/etc/timezone');
+            if ($data !== false) {
+                return trim($data);
+            }
+        }
+
+        // RHEL and CentOS.
+        if (file_exists('/etc/sysconfig/clock')) {
+            $data = parse_ini_file('/etc/sysconfig/clock');
+            if (!empty($data['ZONE'])) {
+                return trim($data['ZONE']);
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Util/TimezoneUtilTest.php
+++ b/tests/Util/TimezoneUtilTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Platformsh\Cli\Tests\Util;
+
+use Platformsh\Cli\Util\TimezoneUtil;
+
+class TimezoneUtilTest extends \PHPUnit_Framework_TestCase
+{
+    private $originalSetting;
+    private $originalIni;
+    private $originalEnv;
+
+    public function setUp()
+    {
+        // Reset to PHP defaults.
+        $this->originalIni = ini_get('date.timezone');
+        $this->originalSetting = date_default_timezone_get();
+        $this->originalEnv = getenv('TZ');
+        ini_set('date.timezone', 'UTC');
+        date_default_timezone_set('UTC');
+        putenv('TZ=');
+    }
+
+    public function tearDown()
+    {
+        // Reset to original settings.
+        ini_set('date.timezone', $this->originalIni);
+        date_default_timezone_set($this->originalSetting);
+        if ($this->originalEnv !== false) {
+            putenv('TZ=' . $this->originalEnv);
+        }
+    }
+
+    public function testGetTimezoneReturnsIni()
+    {
+        // Pick a rare timezone.
+        ini_set('date.timezone', 'Pacific/Galapagos');
+        $this->assertEquals('Pacific/Galapagos', TimezoneUtil::getTimezone());
+    }
+
+    public function testGetTimezoneReturnsCurrent()
+    {
+        ini_set('date.timezone', 'Antarctica/McMurdo');
+        date_default_timezone_set('Antarctica/Troll');
+        $this->assertEquals('Antarctica/Troll', TimezoneUtil::getTimezone());
+    }
+
+    public function testGetTimezoneReturnsEnvVar()
+    {
+        @ini_set('date.timezone', '');
+        putenv('TZ=Arctic/Longyearbyen');
+        $this->assertEquals('Arctic/Longyearbyen', TimezoneUtil::getTimezone());
+    }
+
+    public function testGetTimezoneReturnsSomething()
+    {
+        $this->assertNotEmpty(TimezoneUtil::getTimezone());
+    }
+}


### PR DESCRIPTION
This preserves the system timezone detection, in case someone was relying on it, but also prioritizes `date.timezone` and the `TZ` environment variable (which are a lot easier for the user to control).