### PR TITLE
Compress and remove whitespace from the generated Phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -30,5 +30,10 @@
   ],
   "main": "bin/platform",
   "output": "platform.phar",
-  "stub": "stub.php"
+  "stub": "stub.php",
+  "compression": "BZ2",
+  "compactors": [
+    "Herrera\\Box\\Compactor\\Json",
+    "Herrera\\Box\\Compactor\\Php"
+  ]
 }

--- a/box.json
+++ b/box.json
@@ -31,7 +31,7 @@
   "main": "bin/platform",
   "output": "platform.phar",
   "stub": "stub.php",
-  "compression": "BZ2",
+  "compression": "GZ",
   "compactors": [
     "Herrera\\Box\\Compactor\\Json",
     "Herrera\\Box\\Compactor\\Php"


### PR DESCRIPTION
Produces 783KB archive - the current one is 3.3MB. It would possibly have an adverse effect on performance or compatibility.