### PR TITLE
[db:dump] Remove --no-autocommit and simplify mysqldump args

### DIFF
--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -142,7 +142,7 @@ class DbDumpCommand extends CommandBase
                 break;
 
             default:
-                $dumpCommand = 'mysqldump --no-autocommit --single-transaction --opt --quote-names '
+                $dumpCommand = 'mysqldump --single-transaction '
                     . $relationships->getSqlCommandArgs('mysqldump', $database);
                 if ($schemaOnly) {
                     $dumpCommand .= ' --no-data';


### PR DESCRIPTION
* `--no-autocommit` causes problems with importing large tables into Galera
* `--opt` and `--quote-names` are enabled by default, so we do not need to specify them
* `--single-transaction` recommends `--quick`, but that is also enabled by `--opt`, which is default