### PR TITLE
Improve user:add to allow setting roles on all environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ tunnel
   tunnel:list (tunnels)                     List SSH tunnels
   tunnel:open                               Open SSH tunnels to an app's relationships
 user
-  user:add                                  Add a user to the project
+  user:add (user:update)                    Add a user to the project, or set their role(s)
   user:delete                               Delete a user from the project
   user:list (users)                         List project users
   user:role                                 View or change a user's role

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ tunnel
 user
   user:add (user:update)                    Add a user to the project, or set their role(s)
   user:delete                               Delete a user from the project
+  user:get                                  View a user's role(s)
   user:list (users)                         List project users
-  user:role                                 View or change a user's role
 variable
   variable:delete                           Delete a variable from an environment
   variable:get (variables, vget)            View variable(s) for an environment

--- a/src/Command/User/UserListCommand.php
+++ b/src/Command/User/UserListCommand.php
@@ -45,6 +45,14 @@ class UserListCommand extends CommandBase
         ksort($rows);
 
         $table->render(array_values($rows), ['Email address', 'Name', 'Project role', 'ID']);
+
+        if (!$table->formatIsMachineReadable()) {
+            $this->stdErr->writeln('');
+            $executable = $this->config()->get('application.executable');
+            $this->stdErr->writeln("To view a user's role(s), run: <info>$executable user:get [email]</info>");
+            $this->stdErr->writeln("To change a user's role(s), run: <info>$executable user:add [email]</info>");
+        }
+
         return 0;
     }
 }

--- a/src/Command/User/UserRoleCommand.php
+++ b/src/Command/User/UserRoleCommand.php
@@ -12,25 +12,24 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class UserRoleCommand extends CommandBase
 {
-
     protected function configure()
     {
         $this
-            ->setName('user:role')
-            ->setDescription("View or change a user's role")
-            ->addArgument('email', InputArgument::REQUIRED, "The user's email address")
-            ->addOption('role', 'r', InputOption::VALUE_REQUIRED, "A new role for the user")
+            ->setName('user:get')
+            ->setDescription("View a user's role(s)")
+            ->addArgument('email', InputArgument::OPTIONAL, "The user's email address")
             ->addOption('level', 'l', InputOption::VALUE_REQUIRED, "The role level ('project' or 'environment')")
-            ->addOption('pipe', null, InputOption::VALUE_NONE, 'Output the role only');
+            ->addOption('pipe', null, InputOption::VALUE_NONE, 'Output the role to stdout (after making any changes)');
         $this->addProjectOption()
              ->addEnvironmentOption()
              ->addNoWaitOption();
+
+        // Backwards compatibility.
+        $this->setHiddenAliases(['user:role']);
+        $this->addOption('role', 'r', InputOption::VALUE_REQUIRED, "[Deprecated: use user:update to change a user's role(s)]");
+
         $this->addExample("View Alice's role on the project", 'alice@example.com');
         $this->addExample("View Alice's role on the environment", 'alice@example.com --level environment');
-        $this->addExample(
-            "Give Alice the 'contributor' role on the environment 'test'",
-            'alice@example.com --level environment --environment test --role contributor'
-        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -46,11 +45,31 @@ class UserRoleCommand extends CommandBase
         $this->validateInput($input, $level !== 'environment');
         $project = $this->getSelectedProject();
 
+        $this->warnAboutDeprecatedOptions(['role']);
+
+        /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+        $questionHelper = $this->getService('question_helper');
+
+        // Load the user.
+        $email = $input->getArgument('email');
+        if ($email === null && $input->isInteractive()) {
+            $choices = [];
+            foreach ($project->getUsers() as $access) {
+                $account = $this->api()->getAccount($access);
+                $choices[$account['email']] = sprintf('%s (%s)', $account['display_name'], $account['email']);
+            }
+            $email = $questionHelper->choose($choices, 'Enter a number to choose a user:');
+        }
+        $projectAccess = $this->api()->loadProjectAccessByEmail($project, $email);
+        if (!$projectAccess) {
+            $this->stdErr->writeln("User not found: <error>$email</error>");
+
+            return 1;
+        }
+
         if ($level === null && $role && $this->hasSelectedEnvironment() && $input->isInteractive()) {
             $environment = $this->getSelectedEnvironment();
-            /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
-            $questionHelper = $this->getService('question_helper');
-            $question = new ChoiceQuestion('For which access level do you want to set the role?', [
+            $question = new ChoiceQuestion('What role level do you want to set?', [
                 'project' => 'The project',
                 'environment' => sprintf('The environment (%s)', $environment->id),
             ]);
@@ -69,100 +88,35 @@ class UserRoleCommand extends CommandBase
             return 1;
         }
 
-        // Load the user.
-        $email = $input->getArgument('email');
-        $projectAccess = $this->api()->loadProjectAccessByEmail($project, $email);
-        if (!$projectAccess) {
-            $this->stdErr->writeln("User not found: <error>$email</error>");
-
-            return 1;
-        }
-
-        // Get the current role.
-        if ($level !== 'environment') {
-            $currentRole = $projectAccess->role;
-            $environmentAccess = false;
-        } else {
-            $environmentAccess = $this->getSelectedEnvironment()->getUser($projectAccess->id);
-            $currentRole = $environmentAccess === false ? 'none' : $environmentAccess->role;
-        }
-
-        if ($role === $currentRole) {
-            $this->stdErr->writeln("There is nothing to change");
-        } elseif ($role && $project->owner === $projectAccess->id) {
-            $this->stdErr->writeln(sprintf(
-                'The user <error>%s</error> is the owner of the project %s.',
-                $email,
-                $this->api()->getProjectLabel($project, 'error')
-            ));
-            $this->stdErr->writeln("You cannot change the role of the project's owner.");
-            return 1;
-        } elseif ($role && $level === 'environment' && $projectAccess->role === ProjectAccess::ROLE_ADMIN) {
-            $this->stdErr->writeln(sprintf(
-                'The user <error>%s</error> is an admin on the project %s.',
-                $email,
-                $this->api()->getProjectLabel($project, 'error')
-            ));
-            $this->stdErr->writeln('You cannot change the environment-level role of a project admin.');
-            return 1;
-        } elseif ($role && $level !== 'environment') {
-            $result = $projectAccess->update(['role' => $role]);
-            $this->stdErr->writeln("User <info>$email</info> updated");
-        } elseif ($role && $level === 'environment') {
-            $environment = $this->getSelectedEnvironment();
-            if ($role === 'none') {
-                if ($environmentAccess instanceof EnvironmentAccess) {
-                    $result = $environmentAccess->delete();
-                }
-            } elseif ($environmentAccess instanceof EnvironmentAccess) {
-                $result = $environmentAccess->update(['role' => $role]);
-            } else {
-                $result = $environment->addUser($projectAccess->id, $role);
+        $args = [
+            'email' => $email,
+            '--role' => [],
+            '--project' => $project->id,
+        ];
+        if ($role) {
+            if ($level === 'project') {
+                $args['--role'][] = $role;
+            } elseif ($level === 'environment') {
+                $args['--role'][] = $this->getSelectedEnvironment()->id . ':' . $role;
             }
-            $this->stdErr->writeln("User <info>$email</info> updated");
+        } else {
+            $args['--yes'] = true;
         }
-
-        if (isset($result) && !$input->getOption('no-wait')) {
-            /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
-            $activityMonitor = $this->getService('activity_monitor');
-            $activityMonitor->waitMultiple($result->getActivities(), $project);
+        $result = $this->runOtherCommand($role ? 'user:update' : 'user:add', $args, $output);
+        if ($result !== 0) {
+            return $result;
         }
 
         if ($input->getOption('pipe')) {
+            $uuid = $projectAccess->id;
             if ($level !== 'environment') {
-                $output->writeln($projectAccess->role);
+                $projectAccess = $this->api()->loadProjectAccessByEmail($project, $email);
+                $currentRole = $projectAccess ? $projectAccess->role : 'none';
             } else {
-                $access = $this->getSelectedEnvironment()->getUser($projectAccess->id);
-                $output->writeln($access ? $access->role : 'none');
+                $environmentAccess = $this->getSelectedEnvironment()->getUser($uuid);
+                $currentRole = $environmentAccess ? $environmentAccess->role : 'none';
             }
-
-            return 0;
-        }
-
-        if ($level !== 'environment') {
-            $output->writeln("Project role: <info>{$projectAccess->role}</info>");
-        }
-
-        $environments = [];
-        if ($level === 'environment') {
-            $environments = [$this->getSelectedEnvironment()];
-        } elseif ($level === null && $projectAccess->role !== ProjectAccess::ROLE_ADMIN) {
-            $environments = $this->api()->getEnvironments($project);
-            $this->api()->sortResources($environments, 'id');
-            if ($this->hasSelectedEnvironment()) {
-                $environment = $this->getSelectedEnvironment();
-                unset($environments[$environment->id]);
-                array_splice($environments, 0, 0, [$environment->id => $environment]);
-            }
-        }
-
-        foreach ($environments as $environment) {
-            $access = $environment->getUser($projectAccess->id);
-            $output->writeln(sprintf(
-                'Role for environment %s: <info>%s</info>',
-                $environment->id,
-                $access ? $access->role : 'none'
-            ));
+            $output->writeln($currentRole);
         }
 
         return 0;


### PR DESCRIPTION
Example:

```
$ platform user:add user@example.com -r viewer -r master:viewer -r develop:contributor
Adding the user user@example.com to My Project (abcdef123456):
  Project role: viewer
  Role on develop: contributor
  Role on master: viewer

Adding users can result in additional charges.

Are you sure you want to add this user? [Y/n] 
```