### PR TITLE
Add "environment:redeploy" command.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -120,6 +120,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Environment\EnvironmentInitCommand();
         $commands[] = new Command\Environment\EnvironmentMergeCommand();
         $commands[] = new Command\Environment\EnvironmentPushCommand();
+        $commands[] = new Command\Environment\EnvironmentRedeployCommand();
         $commands[] = new Command\Environment\EnvironmentRelationshipsCommand();
         $commands[] = new Command\Environment\EnvironmentSshCommand();
         $commands[] = new Command\Environment\EnvironmentSynchronizeCommand();

--- a/src/Command/Environment/EnvironmentRedeployCommand.php
+++ b/src/Command/Environment/EnvironmentRedeployCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Platformsh\Cli\Command\Environment;
+
+use Platformsh\Cli\Command\Variable\VariableSetCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class EnvironmentRedeployCommand extends VariableSetCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('environment:redeploy')
+            ->setAliases(['redeploy'])
+            ->setDescription('Redeploys an environment by setting a variable. This will refresh Lets Encrypt certificates if within two weeks of renewal.')
+            ->addArgument('name', InputArgument::OPTIONAL, 'The variable name', 'redeploy')
+            ->addArgument('value', InputArgument::OPTIONAL, 'The variable value', date(DATE_ATOM, time()))
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Mark the value as JSON');
+        $this->addProjectOption()
+            ->addEnvironmentOption()
+            ->addNoWaitOption();
+    }
+}


### PR DESCRIPTION
Something to make life a little simpler for some of our users. This is largely a wrapper for vset which defaults the variable settings, and allows us to tell people to `platform redeploy` without going into unnecessary detail.

```
platform redeploy [--json] [-p|--project PROJECT] [--host HOST] [-e|--environment ENVIRONMENT] [-W|--no-wait] [--] [<name>] [<value>]

Arguments:
  name                           The variable name [default: "redeploy"]
  value                          The variable value [default: "2018-02-15T10:59:20+00:00"]

Options:
      --json                     Mark the value as JSON
  -p, --project=PROJECT          The project ID
      --host=HOST                The project's API hostname
  -e, --environment=ENVIRONMENT  The environment ID
  -W, --no-wait                  Do not wait for the operation to complete
  -h, --help                     Display this help message
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
  -y, --yes                      Answer "yes" to all prompts; disable interaction
  -n, --no                       Answer "no" to all prompts
  -v|vv|vvv, --verbose           Increase the verbosity of messages
```