### PR TITLE
Add redeploy command, and some automatic --no-wait detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.16 <2.0",
-        "platformsh/client": ">=0.15.0 <2.0",
+        "platformsh/client": ">=0.16.0 <2.0",
         "symfony/console": "^3.0 !=3.2.5 !=3.2.6",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.16 <2.0",
-        "platformsh/client": ">=0.16.0 <2.0",
+        "platformsh/client": ">=0.16.2 <2.0",
         "symfony/console": "^3.0 !=3.2.5 !=3.2.6",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "83c1ecc8a281df5af2b3e113d833f7b7",
+    "content-hash": "3ec46d331a98339b614a5b1d879727fc",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -711,16 +711,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "v0.16.0",
+            "version": "v0.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "e2a3cba21998e12d46e976249798c397bad7235c"
+                "reference": "d148ca8d4c3239ada8441515a4d8a02067037c96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/e2a3cba21998e12d46e976249798c397bad7235c",
-                "reference": "e2a3cba21998e12d46e976249798c397bad7235c",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/d148ca8d4c3239ada8441515a4d8a02067037c96",
+                "reference": "d148ca8d4c3239ada8441515a4d8a02067037c96",
                 "shasum": ""
             },
             "require": {
@@ -756,7 +756,7 @@
                 }
             ],
             "description": "Platform.sh API client",
-            "time": "2018-02-21T10:53:34+00:00"
+            "time": "2018-03-01T00:18:35+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "61139468c3903d4897f8fcfece451e34",
+    "content-hash": "83c1ecc8a281df5af2b3e113d833f7b7",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -711,16 +711,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "v0.15.0",
+            "version": "v0.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "1ab0bd8d229dda78b4a545379fd107de4ead872c"
+                "reference": "e2a3cba21998e12d46e976249798c397bad7235c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/1ab0bd8d229dda78b4a545379fd107de4ead872c",
-                "reference": "1ab0bd8d229dda78b4a545379fd107de4ead872c",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/e2a3cba21998e12d46e976249798c397bad7235c",
+                "reference": "e2a3cba21998e12d46e976249798c397bad7235c",
                 "shasum": ""
             },
             "require": {
@@ -756,7 +756,7 @@
                 }
             ],
             "description": "Platform.sh API client",
-            "time": "2018-02-12T10:31:29+00:00"
+            "time": "2018-02-21T10:53:34+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Application.php
+++ b/src/Application.php
@@ -123,6 +123,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Environment\EnvironmentInitCommand();
         $commands[] = new Command\Environment\EnvironmentMergeCommand();
         $commands[] = new Command\Environment\EnvironmentPushCommand();
+        $commands[] = new Command\Environment\EnvironmentRedeployCommand();
         $commands[] = new Command\Environment\EnvironmentRelationshipsCommand();
         $commands[] = new Command\Environment\EnvironmentSshCommand();
         $commands[] = new Command\Environment\EnvironmentSynchronizeCommand();

--- a/src/Command/Activity/ActivityGetCommand.php
+++ b/src/Command/Activity/ActivityGetCommand.php
@@ -68,10 +68,7 @@ class ActivityGetCommand extends CommandBase
 
         $properties = $activity->getProperties();
 
-        // Add the activity "description" as a property.
-        if (!isset($properties['description'])) {
-            $properties['description'] = $activity->getDescription();
-        }
+        $properties['description'] = $activity->getDescription(false);
 
         // Calculate the duration of the activity.
         if (!isset($properties['duration'])) {

--- a/src/Command/Activity/ActivityListCommand.php
+++ b/src/Command/Activity/ActivityListCommand.php
@@ -97,7 +97,7 @@ class ActivityListCommand extends CommandBase
             $row = [
                 new AdaptiveTableCell($activity->id, ['wrap' => false]),
                 $formatter->format($activity['created_at'], 'created_at'),
-                $activity->getDescription(),
+                ActivityMonitor::getFormattedDescription($activity),
                 $activity->getCompletionPercent() . '%',
                 ActivityMonitor::formatState($activity->state),
                 ActivityMonitor::formatResult($activity->result, !$table->formatIsMachineReadable()),

--- a/src/Command/Activity/ActivityLogCommand.php
+++ b/src/Command/Activity/ActivityLogCommand.php
@@ -77,7 +77,7 @@ class ActivityLogCommand extends CommandBase
 
         $this->stdErr->writeln([
             sprintf('<info>Activity ID: </info>%s', $activity->id),
-            sprintf('<info>Description: </info>%s', $activity->getDescription()),
+            sprintf('<info>Description: </info>%s', ActivityMonitor::getFormattedDescription($activity)),
             sprintf('<info>Created: </info>%s', $formatter->format($activity->created_at, 'created_at')),
             sprintf('<info>State: </info>%s', ActivityMonitor::formatState($activity->state)),
             '<info>Log: </info>',

--- a/src/Command/Certificate/CertificateAddCommand.php
+++ b/src/Command/Certificate/CertificateAddCommand.php
@@ -19,7 +19,7 @@ class CertificateAddCommand extends CommandBase
             ->addOption('key', null, InputOption::VALUE_REQUIRED, 'The path to the certificate private key file')
             ->addOption('chain', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The path to the certificate chain file');
         $this->addProjectOption();
-        $this->addNoWaitOption();
+        $this->addWaitOptions();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -39,7 +39,7 @@ class CertificateAddCommand extends CommandBase
 
         $result = $project->addCertificate($options['certificate'], $options['key'], $options['chain']);
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $project);

--- a/src/Command/Certificate/CertificateDeleteCommand.php
+++ b/src/Command/Certificate/CertificateDeleteCommand.php
@@ -19,7 +19,7 @@ class CertificateDeleteCommand extends CommandBase
             ->setDescription('Delete a certificate from the project')
             ->addArgument('id', InputArgument::REQUIRED, 'The certificate ID (or the start of it)');
         $this->addProjectOption();
-        $this->addNoWaitOption();
+        $this->addWaitOptions();
     }
 
     /**
@@ -61,7 +61,7 @@ class CertificateDeleteCommand extends CommandBase
 
         $this->stdErr->writeln(sprintf('The certificate <info>%s</info> has been deleted.', $certificate->id));
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $project);

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -557,14 +557,8 @@ abstract class CommandBase extends Command implements CanHideInListInterface, Mu
         $this->stdErr->writeln([
             '',
             '<comment>The remote environment(s) must be redeployed for the change to take effect.</comment>',
-            "Use 'git push' with new commit(s) to trigger a redeploy.",
+            'To redeploy an environment, run: <info>' . $this->config()->get('application.executable') . ' redeploy</info>',
         ]);
-        if (strpos($this->getName(), 'variable:') !== 0) {
-            $this->stdErr->writeln([
-                'Alternatively, add or change an environment variable, e.g.',
-                '  <comment>' . $this->config()->get('application.executable') . ' vset _redeploy "$(date)"</comment>'
-            ]);
-        }
     }
 
     /**

--- a/src/Command/Domain/DomainAddCommand.php
+++ b/src/Command/Domain/DomainAddCommand.php
@@ -17,7 +17,7 @@ class DomainAddCommand extends DomainCommandBase
             ->setName('domain:add')
             ->setDescription('Add a new domain to the project');
         $this->addDomainOptions();
-        $this->addProjectOption()->addNoWaitOption();
+        $this->addProjectOption()->addWaitOptions();
         $this->addExample('Add the domain example.com', 'example.com');
         $this->addExample(
             'Add the domain secure.example.com with SSL enabled',
@@ -54,7 +54,7 @@ class DomainAddCommand extends DomainCommandBase
             return 1;
         }
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $project);

--- a/src/Command/Domain/DomainDeleteCommand.php
+++ b/src/Command/Domain/DomainDeleteCommand.php
@@ -17,7 +17,7 @@ class DomainDeleteCommand extends CommandBase
             ->setName('domain:delete')
             ->setDescription('Delete a domain from the project')
             ->addArgument('name', InputArgument::REQUIRED, 'The domain name');
-        $this->addProjectOption()->addNoWaitOption();
+        $this->addProjectOption()->addWaitOptions();
         $this->addExample('Delete the domain example.com', 'example.com');
     }
 
@@ -48,7 +48,7 @@ class DomainDeleteCommand extends CommandBase
 
         $this->stdErr->writeln("The domain <info>$name</info> has been deleted.");
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $project);

--- a/src/Command/Domain/DomainUpdateCommand.php
+++ b/src/Command/Domain/DomainUpdateCommand.php
@@ -16,7 +16,7 @@ class DomainUpdateCommand extends DomainCommandBase
             ->setName('domain:update')
             ->setDescription('Update a domain');
         $this->addDomainOptions();
-        $this->addProjectOption()->addNoWaitOption();
+        $this->addProjectOption()->addWaitOptions();
         $this->addExample(
             'Update the certificate for the domain example.com',
             'example.com --cert secure-example-com.crt --key secure-example-com.key'
@@ -60,7 +60,7 @@ class DomainUpdateCommand extends DomainCommandBase
 
         $result = $domain->update(['ssl' => $this->sslOptions]);
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $project);

--- a/src/Command/Environment/EnvironmentActivateCommand.php
+++ b/src/Command/Environment/EnvironmentActivateCommand.php
@@ -20,7 +20,7 @@ class EnvironmentActivateCommand extends CommandBase
             ->addOption('parent', null, InputOption::VALUE_REQUIRED, 'Set a new environment parent before activating');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Activate the environments "develop" and "stage"', 'develop stage');
     }
 
@@ -112,7 +112,7 @@ class EnvironmentActivateCommand extends CommandBase
         $success = $processed >= $count;
 
         if ($processed) {
-            if (!$input->getOption('no-wait')) {
+            if ($this->shouldWait($input)) {
                 /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
                 $activityMonitor = $this->getService('activity_monitor');
                 $result = $activityMonitor->waitMultiple($activities, $this->getSelectedProject());

--- a/src/Command/Environment/EnvironmentBranchCommand.php
+++ b/src/Command/Environment/EnvironmentBranchCommand.php
@@ -34,7 +34,7 @@ class EnvironmentBranchCommand extends CommandBase
             );
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption("Do not wait for the environment to be branched");
+             ->addWaitOptions();
         Ssh::configureInput($this->getDefinition());
         $this->addExample('Create a new branch "sprint-2", based on "develop"', 'sprint-2 develop');
     }
@@ -153,7 +153,7 @@ class EnvironmentBranchCommand extends CommandBase
         }
 
         $remoteSuccess = true;
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $remoteSuccess = $activityMonitor->waitAndLog(

--- a/src/Command/Environment/EnvironmentDeleteCommand.php
+++ b/src/Command/Environment/EnvironmentDeleteCommand.php
@@ -25,7 +25,7 @@ class EnvironmentDeleteCommand extends CommandBase
             ->addOption('exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Environments not to delete');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Delete the environments "test" and "example-1"', 'test example-1');
         $this->addExample('Delete all inactive environments', '--inactive');
         $this->addExample('Delete all environments merged with "master"', '--merged master');
@@ -201,7 +201,7 @@ EOF
                 if ($questionHelper->confirm("Are you sure you want to delete the environment <comment>$environmentId</comment>?")) {
                     $deactivate[$environmentId] = $environment;
                     if (!$input->getOption('no-delete-branch')
-                        && !$input->getOption('no-wait')
+                        && $this->shouldWait($input)
                         && ($input->getOption('delete-branch')
                             || (
                                 $input->isInteractive()
@@ -235,7 +235,7 @@ EOF
             }
         }
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             if (!$activityMonitor->waitMultiple($deactivateActivities, $this->getSelectedProject())) {

--- a/src/Command/Environment/EnvironmentHttpAccessCommand.php
+++ b/src/Command/Environment/EnvironmentHttpAccessCommand.php
@@ -37,7 +37,7 @@ class EnvironmentHttpAccessCommand extends CommandBase
             );
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Require a username and password', '--auth myname:mypassword');
         $this->addExample('Restrict access to only one IP address', '--access deny:any --access allow:69.208.1.192');
         $this->addExample('Remove the password requirement, keeping IP restrictions', '--auth 0');
@@ -197,7 +197,7 @@ class EnvironmentHttpAccessCommand extends CommandBase
                 $success = true;
                 if (!$result->countActivities()) {
                     $this->redeployWarning();
-                } elseif (!$input->getOption('no-wait')) {
+                } elseif ($this->shouldWait($input)) {
                     /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
                     $activityMonitor = $this->getService('activity_monitor');
                     $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Environment/EnvironmentInfoCommand.php
+++ b/src/Command/Environment/EnvironmentInfoCommand.php
@@ -31,7 +31,7 @@ class EnvironmentInfoCommand extends CommandBase
         Table::configureInput($this->getDefinition());
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Read all environment properties')
              ->addExample("Show the environment's status", 'status')
              ->addExample('Show the date the environment was created', 'created_at')
@@ -60,7 +60,7 @@ class EnvironmentInfoCommand extends CommandBase
 
         $value = $input->getArgument('value');
         if ($value !== null) {
-            return $this->setProperty($property, $value, $environment, $input->getOption('no-wait'));
+            return $this->setProperty($property, $value, $environment, !$this->shouldWait($input));
         }
 
         switch ($property) {

--- a/src/Command/Environment/EnvironmentInitCommand.php
+++ b/src/Command/Environment/EnvironmentInitCommand.php
@@ -23,7 +23,7 @@ class EnvironmentInitCommand extends CommandBase
             ->addOption('profile', null, InputOption::VALUE_REQUIRED, 'The name of the profile');
         $this->addProjectOption()
             ->addEnvironmentOption()
-            ->addNoWaitOption();
+            ->addWaitOptions();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -58,7 +58,7 @@ class EnvironmentInitCommand extends CommandBase
 
         $this->api()->clearEnvironmentsCache($environment->project);
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitAndLog($activity);

--- a/src/Command/Environment/EnvironmentMergeCommand.php
+++ b/src/Command/Environment/EnvironmentMergeCommand.php
@@ -18,7 +18,7 @@ class EnvironmentMergeCommand extends CommandBase
             ->addArgument('environment', InputArgument::OPTIONAL, 'The environment to merge');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Merge the environment "sprint-2" into its parent', 'sprint-2');
         $this->setHelp(
             'This command will initiate a Git merge of the specified environment into its parent environment.'
@@ -63,7 +63,7 @@ class EnvironmentMergeCommand extends CommandBase
         $this->api()->clearEnvironmentsCache($selectedEnvironment->project);
 
         $activity = $selectedEnvironment->merge();
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitAndLog(

--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -26,7 +26,7 @@ class EnvironmentPushCommand extends CommandBase
             ->addOption('set-upstream', 'u', InputOption::VALUE_NONE, 'Set the target environment as the upstream for the source branch')
             ->addOption('activate', null, InputOption::VALUE_NONE, 'Activate the environment after pushing')
             ->addOption('parent', null, InputOption::VALUE_REQUIRED, 'Set a new environment parent (only used with --activate)');
-        $this->addNoWaitOption('After pushing, do not wait for build or deploy');
+        $this->addWaitOptions();
         $this->addProjectOption()
             ->addEnvironmentOption();
         Ssh::configureInput($this->getDefinition());
@@ -145,7 +145,7 @@ class EnvironmentPushCommand extends CommandBase
         $ssh = $this->getService('ssh');
         $extraSshOptions = [];
         $env = [];
-        if ($input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             $extraSshOptions['SendEnv'] = 'PLATFORMSH_PUSH_NO_WAIT';
             $env['PLATFORMSH_PUSH_NO_WAIT'] = '1';
         }

--- a/src/Command/Environment/EnvironmentRedeployCommand.php
+++ b/src/Command/Environment/EnvironmentRedeployCommand.php
@@ -16,7 +16,7 @@ class EnvironmentRedeployCommand extends CommandBase
             ->setDescription('Redeploy an environment');
         $this->addProjectOption()
             ->addEnvironmentOption();
-        $this->addNoWaitOption();
+        $this->addWaitOptions();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -33,7 +33,7 @@ class EnvironmentRedeployCommand extends CommandBase
 
         $activity = $environment->redeploy();
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitAndLog($activity);

--- a/src/Command/Environment/EnvironmentRedeployCommand.php
+++ b/src/Command/Environment/EnvironmentRedeployCommand.php
@@ -1,0 +1,47 @@
+<?php
+namespace Platformsh\Cli\Command\Environment;
+
+use Platformsh\Cli\Command\CommandBase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnvironmentRedeployCommand extends CommandBase
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('environment:redeploy')
+            ->setAliases(['redeploy'])
+            ->setDescription('Redeploy an environment');
+        $this->addProjectOption()
+            ->addEnvironmentOption();
+        $this->addNoWaitOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->validateInput($input);
+
+        $environment = $this->getSelectedEnvironment();
+
+        /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+        $questionHelper = $this->getService('question_helper');
+        if (!$questionHelper->confirm('Are you sure you want to redeploy the environment <comment>' . $environment->id . '</comment>?')) {
+            return 1;
+        }
+
+        $activity = $environment->redeploy();
+
+        if (!$input->getOption('no-wait')) {
+            /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
+            $activityMonitor = $this->getService('activity_monitor');
+            $success = $activityMonitor->waitAndLog($activity);
+            if (!$success) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/Environment/EnvironmentSynchronizeCommand.php
+++ b/src/Command/Environment/EnvironmentSynchronizeCommand.php
@@ -20,7 +20,7 @@ class EnvironmentSynchronizeCommand extends CommandBase implements CompletionAwa
             ->addArgument('synchronize', InputArgument::IS_ARRAY, 'What to synchronize: "code", "data" or both');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->setHelp(<<<EOT
 This command synchronizes to a child environment from its parent environment.
 
@@ -92,7 +92,7 @@ EOT
         $this->stdErr->writeln("Synchronizing environment <info>$environmentId</info>");
 
         $activity = $selectedEnvironment->synchronize($syncData, $syncCode);
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitAndLog(

--- a/src/Command/Integration/IntegrationAddCommand.php
+++ b/src/Command/Integration/IntegrationAddCommand.php
@@ -16,7 +16,7 @@ class IntegrationAddCommand extends IntegrationCommandBase
             ->setName('integration:add')
             ->setDescription('Add an integration to the project');
         $this->getForm()->configureInputDefinition($this->getDefinition());
-        $this->addProjectOption()->addNoWaitOption();
+        $this->addProjectOption()->addWaitOptions();
         $this->addExample(
             'Add an integration with a GitHub repository',
             '--type github --repository myuser/example-repo --token 9218376e14c2797e0d06e8d2f918d45f --fetch-branches 0'
@@ -54,7 +54,7 @@ class IntegrationAddCommand extends IntegrationCommandBase
         $this->stdErr->writeln("Created integration <info>$integration->id</info> (type: {$values['type']})");
 
         $success = true;
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Integration/IntegrationDeleteCommand.php
+++ b/src/Command/Integration/IntegrationDeleteCommand.php
@@ -17,7 +17,7 @@ class IntegrationDeleteCommand extends CommandBase
             ->setName('integration:delete')
             ->addArgument('id', InputArgument::REQUIRED, 'The integration ID')
             ->setDescription('Delete an integration from a project');
-        $this->addProjectOption()->addNoWaitOption();
+        $this->addProjectOption()->addWaitOptions();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -48,7 +48,7 @@ class IntegrationDeleteCommand extends CommandBase
 
         $this->stdErr->writeln(sprintf('Deleted integration <info>%s</info>', $integration->id));
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Integration/IntegrationUpdateCommand.php
+++ b/src/Command/Integration/IntegrationUpdateCommand.php
@@ -17,7 +17,7 @@ class IntegrationUpdateCommand extends IntegrationCommandBase
             ->addArgument('id', InputArgument::REQUIRED, 'The ID of the integration to update')
             ->setDescription('Update an integration');
         $this->getForm()->configureInputDefinition($this->getDefinition());
-        $this->addProjectOption()->addNoWaitOption();
+        $this->addProjectOption()->addWaitOptions();
         $this->addExample(
             'Switch on the "fetch branches" option for a specific integration',
             'ZXhhbXBsZSB --fetch-branches 1'
@@ -71,7 +71,7 @@ class IntegrationUpdateCommand extends IntegrationCommandBase
 
         $this->displayIntegration($integration);
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Project/ProjectInfoCommand.php
+++ b/src/Command/Project/ProjectInfoCommand.php
@@ -29,7 +29,7 @@ class ProjectInfoCommand extends CommandBase
             ->setDescription('Read or set properties for a project');
         PropertyFormatter::configureInput($this->getDefinition());
         Table::configureInput($this->getDefinition());
-        $this->addProjectOption()->addNoWaitOption();
+        $this->addProjectOption()->addWaitOptions();
         $this->addExample('Read all project properties')
              ->addExample("Show the project's Git URL", 'git')
              ->addExample("Change the project's title", 'title "My project"');
@@ -55,7 +55,7 @@ class ProjectInfoCommand extends CommandBase
 
         $value = $input->getArgument('value');
         if ($value !== null) {
-            return $this->setProperty($property, $value, $project, $input->getOption('no-wait'));
+            return $this->setProperty($property, $value, $project, !$this->shouldWait($input));
         }
 
         switch ($property) {

--- a/src/Command/Project/Variable/ProjectVariableDeleteCommand.php
+++ b/src/Command/Project/Variable/ProjectVariableDeleteCommand.php
@@ -18,7 +18,7 @@ class ProjectVariableDeleteCommand extends CommandBase
             ->addArgument('name', InputArgument::REQUIRED, 'The variable name')
             ->setDescription('Delete a variable from a project');
         $this->addProjectOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Delete the variable "example"', 'example');
     }
 
@@ -64,7 +64,7 @@ class ProjectVariableDeleteCommand extends CommandBase
         $success = true;
         if (!$result->countActivities()) {
             $this->redeployWarning();
-        } elseif (!$input->getOption('no-wait')) {
+        } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Project/Variable/ProjectVariableSetCommand.php
+++ b/src/Command/Project/Variable/ProjectVariableSetCommand.php
@@ -24,7 +24,7 @@ class ProjectVariableSetCommand extends CommandBase
             ->addOption('no-visible-runtime', null, InputOption::VALUE_NONE, 'Do not expose this variable at runtime')
             ->setDescription('Set a variable for a project');
         $this->addProjectOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Set the variable "example" to the string "123"', 'example 123');
         $this->addExample('Set the variable "example" to the Boolean TRUE', 'example --json true');
         $this->addExample('Set the variable "example" to a list of values', 'example --json \'["value1", "value2"]\'');
@@ -64,7 +64,7 @@ class ProjectVariableSetCommand extends CommandBase
         $success = true;
         if (!$result->countActivities()) {
             $this->redeployWarning();
-        } elseif (!$input->getOption('no-wait')) {
+        } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Snapshot/SnapshotCreateCommand.php
+++ b/src/Command/Snapshot/SnapshotCreateCommand.php
@@ -17,7 +17,7 @@ class SnapshotCreateCommand extends CommandBase
             ->addArgument('environment', InputArgument::OPTIONAL, 'The environment');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption('Do not wait for the snapshot to complete');
+             ->addWaitOptions();
         $this->setHiddenAliases(['backup', 'environment:backup']);
         $this->addExample('Make a snapshot of the current environment');
         $this->addExample('Request a snapshot (and exit quickly)', '--no-wait');
@@ -44,7 +44,7 @@ class SnapshotCreateCommand extends CommandBase
 
         $this->stdErr->writeln("Creating a snapshot of <info>$environmentId</info>");
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             $this->stdErr->writeln('Waiting for the snapshot to complete...');
 
             // Strongly recommend using --no-wait in a cron job.

--- a/src/Command/Snapshot/SnapshotRestoreCommand.php
+++ b/src/Command/Snapshot/SnapshotRestoreCommand.php
@@ -18,7 +18,7 @@ class SnapshotRestoreCommand extends CommandBase
             ->addArgument('snapshot', InputArgument::OPTIONAL, 'The name of the snapshot. Defaults to the most recent one');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->setHiddenAliases(['environment:restore']);
         $this->addExample('Restore the most recent snapshot');
         $this->addExample('Restore a specific snapshot', '92c9a4b2aa75422efb3d');
@@ -85,7 +85,7 @@ class SnapshotRestoreCommand extends CommandBase
         $this->stdErr->writeln("Restoring snapshot <info>$name</info>");
 
         $activity = $selectedActivity->restore();
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             $this->stdErr->writeln('Waiting for the restore to complete...');
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');

--- a/src/Command/User/UserAddCommand.php
+++ b/src/Command/User/UserAddCommand.php
@@ -25,7 +25,7 @@ class UserAddCommand extends CommandBase
             ->addArgument('email', InputArgument::OPTIONAL, "The user's email address")
             ->addOption('role', 'r', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, "The user's role: 'admin' or 'viewer', or environment-specific role e.g. 'master:contributor' or 'stage:viewer'");
         $this->addProjectOption();
-        $this->addNoWaitOption();
+        $this->addWaitOptions();
         $this->addExample('Add Alice as a project admin', 'alice@example.com -r admin');
         $this->addExample('Make Bob an admin on the "develop" and "stage" environments', 'bob@example.com -r develop:a,stage:a');
     }
@@ -280,7 +280,7 @@ class UserAddCommand extends CommandBase
         }
 
         // Wait for activities to complete.
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             if (!$activityMonitor->waitMultiple($activities, $project)) {

--- a/src/Command/User/UserDeleteCommand.php
+++ b/src/Command/User/UserDeleteCommand.php
@@ -15,7 +15,7 @@ class UserDeleteCommand extends CommandBase
             ->setName('user:delete')
             ->setDescription('Delete a user from the project')
             ->addArgument('email', InputArgument::REQUIRED, "The user's email address");
-        $this->addProjectOption()->addNoWaitOption();
+        $this->addProjectOption()->addWaitOptions();
         $this->addExample('Delete Alice from the project', 'alice@example.com');
     }
 
@@ -53,7 +53,7 @@ class UserDeleteCommand extends CommandBase
 
         $this->stdErr->writeln("User <info>$email</info> deleted");
 
-        if (!$input->getOption('no-wait')) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $project);

--- a/src/Command/User/UserRoleCommand.php
+++ b/src/Command/User/UserRoleCommand.php
@@ -22,7 +22,7 @@ class UserRoleCommand extends CommandBase
             ->addOption('pipe', null, InputOption::VALUE_NONE, 'Output the role to stdout (after making any changes)');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
 
         // Backwards compatibility.
         $this->setHiddenAliases(['user:role']);

--- a/src/Command/Variable/VariableDeleteCommand.php
+++ b/src/Command/Variable/VariableDeleteCommand.php
@@ -19,7 +19,7 @@ class VariableDeleteCommand extends CommandBase
             ->setDescription('Delete a variable from an environment');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Delete the variable "example"', 'example');
     }
 
@@ -69,7 +69,7 @@ class VariableDeleteCommand extends CommandBase
         $success = true;
         if (!$result->countActivities()) {
             $this->redeployWarning();
-        } elseif (!$input->getOption('no-wait')) {
+        } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Variable/VariableDisableCommand.php
+++ b/src/Command/Variable/VariableDisableCommand.php
@@ -21,7 +21,7 @@ class VariableDisableCommand extends CommandBase
             ->setDescription('Disable an enabled environment-level variable');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -54,7 +54,7 @@ class VariableDisableCommand extends CommandBase
         $success = true;
         if (!$result->countActivities()) {
             $this->redeployWarning();
-        } elseif (!$input->getOption('no-wait')) {
+        } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Variable/VariableEnableCommand.php
+++ b/src/Command/Variable/VariableEnableCommand.php
@@ -21,7 +21,7 @@ class VariableEnableCommand extends CommandBase
             ->setDescription('Enable a disabled environment-level variable');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -54,7 +54,7 @@ class VariableEnableCommand extends CommandBase
         $success = true;
         if (!$result->countActivities()) {
             $this->redeployWarning();
-        } elseif (!$input->getOption('no-wait')) {
+        } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Variable/VariableSetCommand.php
+++ b/src/Command/Variable/VariableSetCommand.php
@@ -25,7 +25,7 @@ class VariableSetCommand extends CommandBase
             ->setDescription('Set a variable for an environment');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addNoWaitOption();
+             ->addWaitOptions();
         $this->addExample('Set the variable "example" to the string "123"', 'example 123');
         $this->addExample('Set the variable "example" to the Boolean TRUE', 'example --json true');
         $this->addExample('Set the variable "example" to a list of values', 'example --json \'["value1", "value2"]\'');
@@ -66,7 +66,7 @@ class VariableSetCommand extends CommandBase
         $success = true;
         if (!$result->countActivities()) {
             $this->redeployWarning();
-        } elseif (!$input->getOption('no-wait')) {
+        } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Service/ActivityMonitor.php
+++ b/src/Service/ActivityMonitor.php
@@ -70,7 +70,7 @@ class ActivityMonitor
         $stdErr->writeln(sprintf(
             'Waiting for the activity <info>%s</info> (%s):',
             $activity->id,
-            $activity->getDescription()
+            self::getFormattedDescription($activity)
         ));
 
         // The progress bar will show elapsed time and the activity's state.
@@ -206,7 +206,7 @@ class ActivityMonitor
         // Display success or failure messages for each activity.
         $success = true;
         foreach ($activities as $activity) {
-            $description = $activity->getDescription();
+            $description = self::getFormattedDescription($activity);
             switch ($activity['result']) {
                 case Activity::RESULT_SUCCESS:
                     $stdErr->writeln(sprintf('Activity <info>%s</info> succeeded: %s', $activity->id, $description));
@@ -270,5 +270,25 @@ class ActivityMonitor
         $progressOutput = $output->isDecorated() ? $output : new NullOutput();
 
         return new ProgressBar($progressOutput);
+    }
+
+    /**
+     * Get the formatted description of an activity.
+     *
+     * @param \Platformsh\Client\Model\Activity $activity
+     *
+     * @return string
+     */
+    public static function getFormattedDescription(Activity $activity)
+    {
+        $value = $activity->hasProperty('description')
+            ? $activity->getProperty('description')
+            : $activity->getDescription(true);
+
+        // Replace description HTML fields with underlined plain text.
+        $value = preg_replace('/<[^\/>]+>/', '<options=underscore>', $value);
+        $value = preg_replace('/<\/[^>]+>/', '</>', $value);
+
+        return $value;
     }
 }

--- a/src/Service/QuestionHelper.php
+++ b/src/Service/QuestionHelper.php
@@ -56,6 +56,9 @@ class QuestionHelper extends BaseQuestionHelper
         } elseif ($no && !$yes) {
             $this->output->writeln($questionText . 'n');
             return false;
+        } elseif (!$this->input->isInteractive()) {
+            $this->output->writeln($questionText . ($default ? 'y' : 'n'));
+            return $default;
         }
         $question = new ConfirmationQuestion($questionText, $default);
 


### PR DESCRIPTION
- [x] Should we have `--no-wait` by default? Currently I think that would be a confusing inconsistency (edit: see discussion below - this adds a `shouldWait()` method that detects cron/hooks)
- [ ] Wait for availability of platform.sh version 2.8.x