### PR TITLE
Installer: improvements to environment configuration snippet

### DIFF
--- a/src/Command/Self/SelfInstallCommand.php
+++ b/src/Command/Self/SelfInstallCommand.php
@@ -31,7 +31,6 @@ EOT
             'shell-config.rc',
             'shell-config-bash.rc',
         ];
-        $rcDestination = $configDir . DIRECTORY_SEPARATOR . 'shell-config.rc';
         $fs = new \Symfony\Component\Filesystem\Filesystem();
         foreach ($rcFiles as $rcFile) {
             if (($rcContents = file_get_contents(CLI_ROOT . '/' . $rcFile)) === false) {
@@ -56,13 +55,15 @@ EOT
             }
         }
 
+        $configDirRelative = $this->config()->getUserConfigDir(false);
+        $rcDestination = $configDirRelative . '/' . 'shell-config.rc';
         $suggestedShellConfig = sprintf(
             'export PATH=%s:"$PATH"',
-            escapeshellarg($configDir . '/bin')
+            '"$HOME/"' . escapeshellarg($configDirRelative . '/bin')
         );
         $suggestedShellConfig .= PHP_EOL . sprintf(
-            '[ -f %1$s ] && . %1$s',
-            escapeshellarg($rcDestination)
+            'if [ -f %1$s ]; then . %1$s; fi',
+            '"$HOME/"' . escapeshellarg($rcDestination)
         );
 
         if (strpos($currentShellConfig, $suggestedShellConfig) !== false) {

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -99,11 +99,18 @@ class Config
     }
 
     /**
+     * Get the directory where the CLI is normally installed and configured.
+     *
+     * @param bool $absolute Whether to return an absolute path. If false,
+     *                       the path will be relative to the home directory.
+     *
      * @return string
      */
-    public function getUserConfigDir()
+    public function getUserConfigDir($absolute = true)
     {
-        return $this->fs()->getHomeDirectory() . '/' . $this->get('application.user_config_dir');
+        $path = $this->get('application.user_config_dir');
+
+        return $absolute ? $this->fs()->getHomeDirectory() . '/' . $path : $path;
     }
 
     /**


### PR DESCRIPTION
[x] Ensure the snippet does not return a failure code.
[x] Use "$HOME" for the home directory instead of an absolute path.