### PR TITLE
Adds a scaffold command

### DIFF
--- a/resources/scaffold/default/.platform.app.yaml
+++ b/resources/scaffold/default/.platform.app.yaml
@@ -1,0 +1,42 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The type of the application to build.
+type: php
+build:
+    flavor: composer
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+#    database: 'mysqldb:mysql'
+#    solr: 'solrsearch:solr'
+#    redis: 'rediscache:redis'
+
+variables:
+    php:
+        # Turn display errors off when you're ready to launch.
+        display_errors: On
+
+# The size of the persistent disk of the application (in MB).
+disk: 512
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    # A small placeholder scratch space if needed.
+    "/var": "shared:files/var"
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            # The public directory of the app, relative to its root.
+            root: "web"
+            # The front-controller script to send non-static requests to.
+            passthru: "/index.php"

--- a/resources/scaffold/default/.platform/routes.yaml
+++ b/resources/scaffold/default/.platform/routes.yaml
@@ -1,0 +1,14 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+    cache:
+      enabled: true
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/resources/scaffold/default/.platform/services.yaml
+++ b/resources/scaffold/default/.platform/services.yaml
@@ -1,0 +1,15 @@
+# The services of the project.
+#
+# Each service listed will be deployed
+# to power your Platform.sh project.
+
+#mysqldb:
+#    type: mysql:10.2
+#    disk: 2048
+#
+#rediscache:
+#    type: redis:3.2
+#
+#solrsearch:
+#    type: solr:6.6
+#    disk: 1024

--- a/src/Application.php
+++ b/src/Application.php
@@ -161,6 +161,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Repo\LsCommand();
         $commands[] = new Command\Route\RouteListCommand();
         $commands[] = new Command\Route\RouteGetCommand();
+        $commands[] = new Command\Scaffold\ScaffoldDefault();
         $commands[] = new Command\Self\SelfBuildCommand();
         $commands[] = new Command\Self\SelfInstallCommand();
         $commands[] = new Command\Self\SelfUpdateCommand();

--- a/src/Command/Scaffold/ScaffoldDefault.php
+++ b/src/Command/Scaffold/ScaffoldDefault.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace Platformsh\Cli\Command\Scaffold;
+
+
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Service\Filesystem;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ScaffoldDefault extends CommandBase
+{
+    /**
+     * @var Filesystem
+     */
+    protected $fileHandler;
+
+    /**
+     * Scaffold constructor.
+     */
+    public function __construct($name = null)
+    {
+        $this->fileHandler = new Filesystem();
+
+        parent::__construct($name = null);
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('scaffold:default')
+            ->setAliases(['scaffold'])
+            ->setDescription('Set up basic required files within the project');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $cwd = getcwd();
+        $this->stdErr->writeln('Setting the project root to ' . $cwd);
+
+        $this->setProjectRoot($cwd);
+
+        $this->copyScaffold('default');
+    }
+
+    /**
+     * Copy a directory from /resources/scaffold.
+     *
+     * Only works for the root directory currently.
+     *
+     * @param $template
+     */
+    protected function copyScaffold($template) {
+
+        $target = $this->getProjectRoot();
+
+        $this->stdErr->writeln('Building scaffold in ' . $target);
+
+        $basePath = CLI_ROOT . '/resources/scaffold/' . $template;
+        $this->fileHandler->getFilesystem()->mirror($basePath, $target);
+    }
+}

--- a/src/Service/Filesystem.php
+++ b/src/Service/Filesystem.php
@@ -492,4 +492,14 @@ class Filesystem
         }
         throw new \RuntimeException("Tar command not found");
     }
+
+    /**
+     * @return SymfonyFilesystem
+     */
+    public function getFilesystem()
+    {
+        return $this->fs;
+    }
+
+
 }


### PR DESCRIPTION
Adds a basic scaffold command to create default Platform.sh files.

`scaffold:default (scaffold)`

This copies files from a scaffold folder located in the `resources` directory, where the path `resources/<template-name` corresponds to a usable scaffold.

Only the default scaffold exists currently, for PoC evaluation. The default is currently a PHP application with standard routes and a services file with services commented out.

If this works, additional scaffolds could be created for common runtimes and frameworks, potentially reducing the need for example repositories in some cases. Other possible behaviours include fetching the scaffold from a public git repository instead of storing it locally, which would allow users to build their own scaffolds.