### PR TITLE
Installer: avoid creating a new .bash_profile file

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Other customization is available via environment variables:
 * `PLATFORMSH_CLI_DEBUG`: set to 1 to enable cURL debugging. _Warning_: this will print all request information in the terminal, including sensitive access tokens.
 * `PLATFORMSH_CLI_DISABLE_CACHE`: set to 1 to disable caching
 * `PLATFORMSH_CLI_SESSION_ID`: change user session (default 'default')
+* `PLATFORMSH_CLI_SHELL_CONFIG_FILE`: specify the shell configuration file that the installer should write to (as an absolute path). If not set, a file such as `~/.bashrc` will be chosen automatically. Set this to an empty string to disable writing to a shell config file.
 * `PLATFORMSH_CLI_TOKEN`: an API token. _Warning_: storing a secret in an environment variable can be insecure. It may be better to use `config.yaml` as above, depending on your system. The environment variable is preferable on CI systems like Jenkins and GitLab.
 * `PLATFORMSH_CLI_UPDATES_CHECK`: set to 0 to disable the automatic updates check
 * `CLICOLOR_FORCE`: set to 1 or 0 to force colorized output on or off, respectively

--- a/dist/installer.php
+++ b/dist/installer.php
@@ -303,7 +303,7 @@ function is_ansi()
     // Everywhere else, default to ANSI if stdout is a terminal.
     return (DIRECTORY_SEPARATOR == '\\')
         ? (false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI'))
-        : (function_exists('posix_isatty') && posix_isatty(1));
+        : (function_exists('posix_isatty') && posix_isatty(STDOUT));
 }
 
 /**


### PR DESCRIPTION
1. Avoid creating a new .bash_profile file (on Ubuntu this would override
   .profile)
2. Allow the shell config selection to be overridden with a
   PLATFORMSH_CLI_SHELL_CONFIG_FILE environment variable.