### PR TITLE
[db:dump] Add --no-owner to pg_dump command

### DIFF
--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -130,7 +130,7 @@ class DbDumpCommand extends CommandBase
 
         switch ($database['scheme']) {
             case 'pgsql':
-                $dumpCommand = 'pg_dump --clean --blobs ' . $relationships->getDbCommandArgs('pg_dump', $database);
+                $dumpCommand = 'pg_dump --no-owner --clean --blobs ' . $relationships->getDbCommandArgs('pg_dump', $database);
                 if ($schemaOnly) {
                     $dumpCommand .= ' --schema-only';
                 }


### PR DESCRIPTION
From the pg_dump manual on --no-owner (-O):

> Do not output commands to set ownership of objects to match the original
> database. By default, pg_dump issues ALTER OWNER or SET SESSION AUTHORIZATION
> statements to set ownership of created database objects. These statements will
> fail when the script is run unless it is started by a superuser (or the same
> user that owns all of the objects in the script). To make a script that can be
> restored by any user, but will give that user ownership of all the objects,
> specify -O.