### PR TITLE
Drush alias fixes

### DIFF
--- a/src/Service/Drush.php
+++ b/src/Service/Drush.php
@@ -255,18 +255,6 @@ class Drush
     }
 
     /**
-     * @return string
-     */
-    protected function getAutoRemoveKey()
-    {
-        return preg_replace(
-            '/[^a-z-]+/',
-            '-',
-            str_replace('.', '', strtolower($this->config->get('application.name')))
-        ) . '-auto-remove';
-    }
-
-    /**
      * Get the alias group for a project.
      *
      * @param Project $project

--- a/src/SiteAlias/DrushAlias.php
+++ b/src/SiteAlias/DrushAlias.php
@@ -238,8 +238,10 @@ abstract class DrushAlias implements SiteAliasTypeInterface
             return false;
         }
 
+        // The 'root' can be a relative path, relative to the home directory.
+        // Conveniently, the home directory is the same as the app root.
         $alias = [
-            'root' => '/app/' . $app->getDocumentRoot(),
+            'root' => $app->getDocumentRoot(),
             $this->getAutoRemoveKey() => true,
         ];
 

--- a/src/SiteAlias/DrushAlias.php
+++ b/src/SiteAlias/DrushAlias.php
@@ -60,7 +60,7 @@ abstract class DrushAlias implements SiteAliasTypeInterface
         $autoRemoveKey = $this->getAutoRemoveKey();
         $userDefinedAliases = [];
         foreach ($existingAliases as $name => $alias) {
-            if (!empty($alias[$autoRemoveKey])) {
+            if (!empty($alias[$autoRemoveKey]) || !empty($alias['options'][$autoRemoveKey])) {
                 // This is probably for a deleted environment.
                 continue;
             }
@@ -220,7 +220,9 @@ abstract class DrushAlias implements SiteAliasTypeInterface
     {
         return [
             'root' => $app->getLocalWebRoot(),
-            $this->getAutoRemoveKey() => true,
+            'options' => [
+                $this->getAutoRemoveKey() => true,
+            ],
         ];
     }
 
@@ -242,7 +244,9 @@ abstract class DrushAlias implements SiteAliasTypeInterface
         // Conveniently, the home directory is the same as the app root.
         $alias = [
             'root' => $app->getDocumentRoot(),
-            $this->getAutoRemoveKey() => true,
+            'options' => [
+                $this->getAutoRemoveKey() => true,
+            ],
         ];
 
         $sshUrl = $environment->getSshUrl($app->getName());

--- a/src/SiteAlias/DrushYaml.php
+++ b/src/SiteAlias/DrushYaml.php
@@ -12,13 +12,6 @@ class DrushYaml extends DrushAlias
      */
     protected function getFilename($groupName)
     {
-        // Preserve backwards compatibility for Drush 9-beta.
-        // See issue https://github.com/platformsh/platformsh-cli/issues/655
-        $version = $this->drush->getVersion();
-        if ($version !== false && version_compare($version, '8', '>') && version_compare($version, '9.0.0-rc1', '<')) {
-            return $this->drush->getSiteAliasDir() . '/' . $groupName . '.alias.yml';
-        }
-
         return $this->drush->getSiteAliasDir() . '/' . $groupName . '.site.yml';
     }
 

--- a/tests/Service/DrushServiceTest.php
+++ b/tests/Service/DrushServiceTest.php
@@ -75,8 +75,8 @@ class DrushServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('_local', $aliases);
 
         // Check that YAML aliases exist.
-        $this->assertFileExists($homeDir . '/.drush/site-aliases/test.alias.yml');
-        $aliases = Yaml::parse(file_get_contents($homeDir . '/.drush/site-aliases/test.alias.yml'));
+        $this->assertFileExists($homeDir . '/.drush/site-aliases/test.site.yml');
+        $aliases = Yaml::parse(file_get_contents($homeDir . '/.drush/site-aliases/test.site.yml'));
         $this->assertArrayHasKey('master', $aliases);
         $this->assertArrayHasKey('_local', $aliases);
     }
@@ -145,8 +145,8 @@ class DrushServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('_local--drupal2', $aliases);
 
         // Check that YAML aliases exist.
-        $this->assertFileExists($homeDir . '/.drush/site-aliases/test.alias.yml');
-        $aliases = Yaml::parse(file_get_contents($homeDir . '/.drush/site-aliases/test.alias.yml'));
+        $this->assertFileExists($homeDir . '/.drush/site-aliases/test.site.yml');
+        $aliases = Yaml::parse(file_get_contents($homeDir . '/.drush/site-aliases/test.site.yml'));
         $this->assertArrayHasKey('master--drupal1', $aliases);
         $this->assertArrayHasKey('_local--drupal1', $aliases);
         $this->assertArrayHasKey('master--drupal2', $aliases);


### PR DESCRIPTION
- Use relative path for `root` (to account for differing app roots)
- A globally installed Drush 9 needs the aliases to be in `groupname.site.yml` (rather than `groupname.alias.yml`) but this isn't being picked up when in a particular site that uses Drush 8.
- Drush 9 has moved unknown keys such as `platformsh-cli-auto-remove` under an `options` key.

Todo:
- [x] appears to work with Drush 8.1
- [x] check if this works with other versions (particularly Drush 9+)