### PR TITLE
Fix: browser login does not sufficiently log out from old account

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.22 <2.0",
-        "platformsh/client": ">=0.23.0 <2.0",
+        "platformsh/client": ">=0.23.2 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7316086542b599673424191e18406f6a",
+    "content-hash": "b2769ae9f93d12b94dc0614825c1d4b6",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -712,16 +712,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "v0.23.0",
+            "version": "v0.23.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "9b0fc3004d5abdc3cc54b0bea80f779e23660289"
+                "reference": "028f723d4581b09c28f2ab5029b51a2e9363bd15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/9b0fc3004d5abdc3cc54b0bea80f779e23660289",
-                "reference": "9b0fc3004d5abdc3cc54b0bea80f779e23660289",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/028f723d4581b09c28f2ab5029b51a2e9363bd15",
+                "reference": "028f723d4581b09c28f2ab5029b51a2e9363bd15",
                 "shasum": ""
             },
             "require": {
@@ -757,7 +757,7 @@
                 }
             ],
             "description": "Platform.sh API client",
-            "time": "2019-01-09T14:36:49+00:00"
+            "time": "2019-01-16T17:37:27+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Command/Auth/BrowserLoginCommand.php
+++ b/src/Command/Auth/BrowserLoginCommand.php
@@ -208,13 +208,18 @@ class BrowserLoginCommand extends CommandBase
         $this->stdErr->writeln('Login information received. Verifying...');
         $token = $this->getAccessToken($code, $localUrl, $tokenUrl);
 
-        // Finalize login: clear the cache and save the new credentials.
+        // Finalize login: call logOut() on the old connector, clear the cache
+        // and save the new credentials.
+        $connector = $this->api()->getClient(false)->getConnector();
+        $session = $connector->getSession();
+        $connector->logOut();
+
         /** @var \Doctrine\Common\Cache\CacheProvider $cache */
         $cache = $this->getService('cache');
         $cache->flushAll();
 
         // Save the new tokens to the persistent session.
-        $this->saveAccessToken($token, $this->api()->getClient(false)->getConnector()->getSession());
+        $this->saveAccessToken($token, $session);
 
         // Reset the API client so that it will use the new tokens.
         $client = $this->api()->getClient(false, true);


### PR DESCRIPTION
When already logged in and calling `platform login --force` with a new account, the command successfully logs in, and saves the access tokens in the persistent session. So far, so good. But when the command finishes, the magic destructor (`__destruct()`) is called on the old Connector object, which contains an old OAuth2Plugin object, which contains the old access/refresh tokens. The destructor then overwrites the session with the old tokens.

This commit ensures that the old Session and OAuth2Plugin instances are cleared (via `$connector->logOut()`) and it also ensures that old tokens are revoked.