### PR TITLE
Only show user project choice if they have multiple

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -864,6 +864,10 @@ abstract class CommandBase extends Command implements MultiAwareInterface
         if (!isset($this->input) || !isset($this->output) || !$this->input->isInteractive()) {
             throw new \BadMethodCallException('Not interactive: a project choice cannot be offered.');
         }
+        
+        if (count($projects == 1)) {
+            return $projects[0]->id;
+        }
 
         // Build and sort a list of project options.
         $projectList = [];

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -865,7 +865,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             throw new \BadMethodCallException('Not interactive: a project choice cannot be offered.');
         }
         
-        if (count($projects == 1)) {
+        if (count($projects) == 1) {
             return $projects[0]->id;
         }
 


### PR DESCRIPTION
Users with only a single project shouldn't be prompted to select the project they want to run the command for every time. When a user runs a command and only has one project, they will intend for the command to run for that project.