### PR TITLE
Ensure the service name is in the relationship array

### DIFF
--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -83,6 +83,13 @@ class DbDumpCommand extends CommandBase
                 );
             }
 
+            // If the database path is not in the list of schemas, we have to
+            // use that - it probably indicates an integrated Enterprise
+            // environment.
+            if (!empty($database['path']) && !in_array($database['path'], $schemas, true)) {
+                $schemas = [$database['path']];
+            }
+
             // Provide the user with a choice of schemas.
             $choices = [];
             foreach ($schemas as $schema) {

--- a/src/Command/Db/DbSqlCommand.php
+++ b/src/Command/Db/DbSqlCommand.php
@@ -69,10 +69,15 @@ class DbSqlCommand extends CommandBase
                 );
             }
 
-            // Provide the user with a choice of schemas.
-            if (count($schemas) === 1) {
+            // If the database path is not in the list of schemas, we have to
+            // use that - it probably indicates an integrated Enterprise
+            // environment.
+            if (!empty($database['path']) && !in_array($database['path'], $schemas, true)) {
+                $schema = $database['path'];
+            } elseif (count($schemas) === 1) {
                 $schema = reset($schemas);
             } else {
+                // Provide the user with a choice of schemas.
                 $choices = [];
                 $schemas[] = '(none)';
                 $default = ($database['path'] ?: '(none)');

--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -87,9 +87,15 @@ class Relationships implements InputConfiguringInterface
         $choices = [];
         foreach ($relationships as $name => $relationship) {
             $serviceCount = count($relationship);
-            foreach ($relationship as $key => $service) {
+            foreach ($relationship as $key => $info) {
                 $identifier = $name . ($serviceCount > 1 ? '.' . $key : '');
-                $choices[$identifier] = $identifier;
+                if (isset($info['username']) && (!isset($info['host']) || $info['host'] === '127.0.0.1')) {
+                    $choices[$identifier] = sprintf('%s (%s)', $identifier, $info['username']);
+                } elseif (isset($info['username'], $info['host'])) {
+                    $choices[$identifier] = sprintf('%s (%s@%s)', $identifier, $info['username'], $info['host']);
+                } else {
+                    $choices[$identifier] = $identifier;
+                }
             }
         }
 

--- a/src/Service/RemoteEnvVars.php
+++ b/src/Service/RemoteEnvVars.php
@@ -59,6 +59,24 @@ class RemoteEnvVars
     }
 
     /**
+     * Read a complex environment variable (an associative array) from the application.
+     *
+     * @see \Platformsh\Cli\Service\RemoteEnvVars::getEnvVar()
+     *
+     * @param string $variable
+     * @param string $sshUrl
+     * @param bool   $refresh
+     *
+     * @return array
+     */
+    public function getArrayEnvVar($variable, $sshUrl, $refresh = false)
+    {
+        $value = $this->getEnvVar($variable, $sshUrl, $refresh);
+
+        return json_decode(base64_decode($value), true) ?: [];
+    }
+
+    /**
      * Clear caches for remote environment variables.
      *
      * @param string $sshUrl    The SSH URL to the application.


### PR DESCRIPTION
For #779 

Enterprise databases have a different relationships structure with no service name and an endpoint exposed per schema per relationship.