### PR TITLE
fix(mongo): database authentification

### DIFF
--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -239,7 +239,7 @@ class Relationships implements InputConfiguringInterface
                     $database['port']
                 );
                 if ($schema !== '') {
-                    $args .= '--authenticationDatabase ' . OsUtil::escapePosixShellArg($schema);
+                    $args .= ' --authenticationDatabase ' . OsUtil::escapePosixShellArg($schema);
                     if ($command === 'mongo') {
                         $args .= ' ' . OsUtil::escapePosixShellArg($schema);
                     } else {


### PR DESCRIPTION
Using v3.40.2, we have the following issue when trying to run `platform service:mongo:export`:

![selection_248](https://user-images.githubusercontent.com/2103975/53407076-9d2ab480-39bb-11e9-9780-09d9f3318499.png)

I don't know if there is a test for this because I made a really quick fix, but this should do the work.
