### PR TITLE
Disable pcre.jit in tunnel:open command to work around PHP bug #77260

### DIFF
--- a/bin/platform
+++ b/bin/platform
@@ -6,6 +6,19 @@ if (version_compare(PHP_VERSION, '5.5.9', '<')) {
     exit(1);
 }
 
+// Disable PCRE JIT compilation in commands using pcntl_fork(), to work around
+// a PHP bug in versions >= 7.3. This needs to happen before any runtime code.
+// See: https://bugs.php.net/bug.php?id=77260
+if (isset($GLOBALS['argv'][1])
+    && version_compare(PHP_VERSION, '7.3', '>=')
+    && ini_get('pcre.jit') == 1
+    && extension_loaded('pcntl')) {
+    $command = $GLOBALS['argv'][1];
+    if (strpos($command, ':') !== false && preg_match('/^(t|ser)[a-z]*\:(o|sta)[a-z]*$/', $command)) {
+        ini_set('pcre.jit', 0);
+    }
+}
+
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
 } elseif (file_exists(__DIR__ . '/../../../autoload.php')) {

--- a/src/Command/Tunnel/TunnelOpenCommand.php
+++ b/src/Command/Tunnel/TunnelOpenCommand.php
@@ -45,6 +45,10 @@ EOF
         $project = $this->getSelectedProject();
         $environment = $this->getSelectedEnvironment();
 
+        // Disable PCRE JIT compilation to work around a PHP bug:
+        // https://bugs.php.net/bug.php?id=77260
+        ini_set('pcre.jit', 0);
+
         if ($environment->id === 'master') {
             /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
             $questionHelper = $this->getService('question_helper');

--- a/src/Command/Tunnel/TunnelOpenCommand.php
+++ b/src/Command/Tunnel/TunnelOpenCommand.php
@@ -45,10 +45,6 @@ EOF
         $project = $this->getSelectedProject();
         $environment = $this->getSelectedEnvironment();
 
-        // Disable PCRE JIT compilation to work around a PHP bug:
-        // https://bugs.php.net/bug.php?id=77260
-        ini_set('pcre.jit', 0);
-
         if ($environment->id === 'master') {
             /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
             $questionHelper = $this->getService('question_helper');


### PR DESCRIPTION
PHP bug 77260: https://bugs.php.net/bug.php?id=77260

Somehow this ini_set() doesn't fix the issue if it's included significantly later (but still before the `fork()`).

That leads me to suspect the introduction of other PCRE regexes before this line may reintroduce this bug, so this is fragile.

Addresses issue #774 