### PR TITLE
 Support --worker option for mount commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.22 <2.0",
-        "platformsh/client": ">=0.24.0 <2.0",
+        "platformsh/client": ">=0.25.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34370fc24851ea02e456b002238c26f9",
+    "content-hash": "e8a09855a1029b6ae898d52ac87e71d1",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -713,16 +713,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "v0.24.1",
+            "version": "v0.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "f17027d031bf8a05dddf6dd133d835e055837f93"
+                "reference": "adbc34b87a028f6e0f46ddc5cb02bd1db0a1a52f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/f17027d031bf8a05dddf6dd133d835e055837f93",
-                "reference": "f17027d031bf8a05dddf6dd133d835e055837f93",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/adbc34b87a028f6e0f46ddc5cb02bd1db0a1a52f",
+                "reference": "adbc34b87a028f6e0f46ddc5cb02bd1db0a1a52f",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 }
             ],
             "description": "Platform.sh API client",
-            "time": "2019-05-12T13:50:12+00:00"
+            "time": "2019-05-23T11:13:39+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -7,6 +7,7 @@ use Platformsh\Cli\Exception\LoginRequiredException;
 use Platformsh\Cli\Exception\ProjectNotFoundException;
 use Platformsh\Cli\Exception\RootNotFoundException;
 use Platformsh\Cli\Local\BuildFlavor\Drupal;
+use Platformsh\Cli\Model\SshDestination;
 use Platformsh\Client\Exception\EnvironmentStateException;
 use Platformsh\Client\Model\Deployment\WebApp;
 use Platformsh\Client\Model\Environment;
@@ -808,7 +809,161 @@ abstract class CommandBase extends Command implements MultiAwareInterface
     }
 
     /**
-     * Find the name of the app the user wants to use for an SSH command.
+     * Add the --app and --worker options.
+     */
+    protected function addSshDestinationOptions()
+    {
+        if (!$this->getDefinition()->hasOption('app')) {
+            $this->addAppOption();
+        }
+        if (!$this->getDefinition()->hasOption('worker')) {
+            $this->addOption('worker', null, InputOption::VALUE_REQUIRED, 'A worker name');
+        }
+    }
+
+    /**
+     * Find what app or worker the user wants to SSH to.
+     *
+     * Requires the --app and --worker options to be present.
+     *
+     * @param InputInterface $input
+     *   The user input object.
+     *
+     * @return \Platformsh\Cli\Model\SshDestination\SshDestinationInterface
+     *   An SSH destination.
+     */
+    protected function selectSshDestination(InputInterface $input)
+    {
+        $environment = $this->getSelectedEnvironment();
+        $deployment = $this->api()->getCurrentDeployment($environment, $input->hasOption('refresh') ? $input->getOption('refresh') : null);
+
+        // Validate the --app option, without doing anything with it.
+        $appOption = $input->hasOption('app') ? $input->getOption('app') : null;
+        if ($appOption !== null) {
+            try {
+                $deployment->getWebApp($appOption);
+            } catch (\InvalidArgumentException $e) {
+                throw new ConsoleInvalidArgumentException('Application not found: ' . $appOption);
+            }
+        }
+
+        // Handle the --worker option first, as it's more specific.
+        $workerOption = $input->hasOption('worker') ? $input->getOption('worker') : null;
+        if ($workerOption !== null) {
+            // Check for a conflict with the --app option.
+            if ($appOption !== null
+                && strpos($workerOption, '--') !== false
+                && stripos($workerOption, $appOption . '--') !== 0) {
+                throw new \InvalidArgumentException(sprintf(
+                    'App name "%s" conflicts with worker name "%s"',
+                    $appOption,
+                    $workerOption
+                ));
+            }
+
+            // If we have the app name, load the worker directly.
+            if (strpos($workerOption, '--') !== false || $appOption !== null) {
+                $qualifiedWorkerName = strpos($workerOption, '--') !== false
+                    ? $workerOption
+                    : $appOption . '--' . $workerOption;
+                try {
+                    $worker = $deployment->getWorker($qualifiedWorkerName);
+                } catch (\InvalidArgumentException $e) {
+                    throw new ConsoleInvalidArgumentException('Worker not found: ' . $workerOption);
+                }
+
+                return new SshDestination\Worker($worker, $environment);
+            }
+
+            // If we don't have the app name, find all the possible matching
+            // workers, and ask the user to choose.
+            $suffix = '--' . $workerOption;
+            $suffixLength = strlen($suffix);
+            $workerNames = [];
+            foreach ($deployment->workers as $worker) {
+                if (substr($worker->name, -$suffixLength) === $suffix) {
+                    $workerNames[] = $worker->name;
+                }
+            }
+            if (count($workerNames) === 0) {
+                throw new ConsoleInvalidArgumentException('Worker not found: ' . $workerOption);
+            }
+            if (count($workerNames) === 1) {
+                $workerName = reset($workerNames);
+
+                return new SshDestination\Worker($deployment->getWorker($workerName), $environment);
+            }
+            if (!$input->isInteractive()) {
+                throw new ConsoleInvalidArgumentException(sprintf(
+                    'Ambiguous worker name: %s (matches: %s)',
+                    $workerOption,
+                    implode(', ', $workerNames)
+                ));
+            }
+            /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+            $questionHelper = $this->getService('question_helper');
+            $workerName = $questionHelper->choose(
+                $workerNames,
+                'Enter a number to choose a worker:'
+            );
+
+            return new SshDestination\Worker($deployment->getWorker($workerName), $environment);
+        }
+
+        // Prompt the user to choose between the app(s) or worker(s) that have
+        // been found.
+        $default = null;
+        $appNames = $appOption !== null
+            ? [$appOption]
+            : array_map(function (WebApp $app) { return $app->name; }, $deployment->webapps);
+        if (count($appNames) === 1) {
+            $default = reset($appNames);
+            $choices = [];
+            $choices[$default] = $default . ' (default)';
+        } else {
+            $choices = array_combine($appNames, $appNames);
+        }
+        foreach ($deployment->workers as $worker) {
+            list($appPart, ) = explode('--', $worker->name, 2);
+            if (in_array($appPart, $appNames, true)) {
+                $choices[$worker->name] = $worker->name;
+            }
+        }
+        if (count($choices) === 0) {
+            throw new \RuntimeException('Failed to find apps or workers for environment: ' . $environment->id);
+        }
+        ksort($choices, SORT_NATURAL);
+        if (count($choices) === 1) {
+            $choice = key($choices);
+        } elseif ($input->isInteractive()) {
+            /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+            $questionHelper = $this->getService('question_helper');
+            $choice = $questionHelper->choose(
+                $choices,
+                sprintf('Enter a number to choose %s app or %s worker:',
+                    count($appNames) === 1 ? 'the' : 'an',
+                    count($choices) === 2 ? 'its' : 'a'
+                ),
+                $default
+            );
+        } elseif (count($appNames) === 1) {
+            $choice = reset($appNames);
+        } else {
+            throw new ConsoleInvalidArgumentException(
+                'Specifying the --app or --worker is required in non-interactive mode'
+            );
+        }
+
+        // Match the choice to a worker or app destination.
+        if (strpos($choice, '--') !== false) {
+            return new SshDestination\Worker($deployment->getWorker($choice), $environment);
+        }
+
+        return new SshDestination\App($deployment->getWebApp($choice), $environment);
+    }
+
+    /**
+     * Find the name of the app the user wants to use.
      *
      * @param InputInterface $input
      *   The user input object.

--- a/src/Command/Environment/EnvironmentLogCommand.php
+++ b/src/Command/Environment/EnvironmentLogCommand.php
@@ -25,7 +25,7 @@ class EnvironmentLogCommand extends CommandBase implements CompletionAwareInterf
             ->addOption('tail', null, InputOption::VALUE_NONE, 'Continuously tail the log');
         $this->addProjectOption()
              ->addEnvironmentOption()
-             ->addAppOption();
+             ->addSshDestinationOptions();
         $this->setHiddenAliases(['logs']);
         $this->addExample('Display a choice of logs that can be read');
         $this->addExample('Read the deploy log', 'deploy');
@@ -41,9 +41,8 @@ class EnvironmentLogCommand extends CommandBase implements CompletionAwareInterf
             throw new InvalidArgumentException('The --tail option cannot be used with "multi"');
         }
 
-        $selectedEnvironment = $this->getSelectedEnvironment();
-        $appName = $this->selectApp($input);
-        $sshUrl = $selectedEnvironment->getSshUrl($appName);
+        $sshDestination = $this->selectSshDestination($input);
+        $sshUrl = $sshDestination->getSshUrl();
 
         /** @var \Platformsh\Cli\Service\Shell $shell */
         $shell = $this->getService('shell');

--- a/src/Command/Mount/MountCommandBase.php
+++ b/src/Command/Mount/MountCommandBase.php
@@ -3,28 +3,10 @@
 namespace Platformsh\Cli\Command\Mount;
 
 use Platformsh\Cli\Command\CommandBase;
-use Platformsh\Cli\Model\AppConfig;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class MountCommandBase extends CommandBase
 {
-    /**
-     * Get the remote application config.
-     *
-     * @param string $appName
-     * @param bool   $refresh
-     *
-     * @return array
-     */
-    protected function getAppConfig($appName, $refresh = true)
-    {
-        $webApp = $this->api()
-            ->getCurrentDeployment($this->getSelectedEnvironment(), $refresh)
-            ->getWebApp($appName);
-
-        return AppConfig::fromWebApp($webApp)->getNormalized();
-    }
-
     /**
      * Format the mounts as an array of options for a ChoiceQuestion.
      *
@@ -66,19 +48,16 @@ abstract class MountCommandBase extends CommandBase
     /**
      * Push the local contents to the chosen mount.
      *
-     * @param string $appName
+     * @param string $sshUrl
      * @param string $mountPath
      * @param string $localPath
      * @param bool   $up
      * @param array  $options
      */
-    protected function runSync($appName, $mountPath, $localPath, $up, array $options = [])
+    protected function runSync($sshUrl, $mountPath, $localPath, $up, array $options = [])
     {
         /** @var \Platformsh\Cli\Service\Shell $shell */
         $shell = $this->getService('shell');
-
-        $sshUrl = $this->getSelectedEnvironment()
-            ->getSshUrl($appName);
 
         $params = ['rsync', '--archive', '--compress', '--human-readable'];
 

--- a/src/Command/Mount/MountDownloadCommand.php
+++ b/src/Command/Mount/MountDownloadCommand.php
@@ -27,7 +27,7 @@ class MountDownloadCommand extends MountCommandBase
             ->addOption('refresh', null, InputOption::VALUE_NONE, 'Whether to refresh the cache');
         $this->addProjectOption();
         $this->addEnvironmentOption();
-        $this->addAppOption();
+        $this->addSshDestinationOptions();
     }
 
     /**
@@ -37,17 +37,17 @@ class MountDownloadCommand extends MountCommandBase
     {
         $this->validateInput($input);
 
-        $appName = $this->selectApp($input);
-        $appConfig = $this->getAppConfig($appName, (bool) $input->getOption('refresh'));
+        $sshDestination = $this->selectSshDestination($input);
+        $mounts = $sshDestination->getMounts();
 
-        if (empty($appConfig['mounts'])) {
-            $this->stdErr->writeln(sprintf('The app "%s" doesn\'t define any mounts.', $appConfig['name']));
+        if (empty($mounts)) {
+            $this->stdErr->writeln(sprintf('The %s "%s" doesn\'t define any mounts.', $sshDestination->getType(), $sshDestination->getName()));
 
             return 1;
         }
         /** @var \Platformsh\Cli\Service\Mount $mountService */
         $mountService = $this->getService('mount');
-        $mounts = $mountService->normalizeMounts($appConfig['mounts']);
+        $mounts = $mountService->normalizeMounts($mounts);
 
         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
         $questionHelper = $this->getService('question_helper');
@@ -55,7 +55,7 @@ class MountDownloadCommand extends MountCommandBase
         $fs = $this->getService('fs');
 
         if ($input->getOption('mount')) {
-            $mountPath = $mountService->validateMountPath($input->getOption('mount'), $mounts);
+            $mountPath = $mountService->matchMountPath($input->getOption('mount'), $mounts);
         } elseif ($input->isInteractive()) {
             $mountPath = $questionHelper->choose(
                 $this->getMountsAsOptions($mounts),
@@ -72,7 +72,7 @@ class MountDownloadCommand extends MountCommandBase
         if ($input->getOption('target')) {
             $target = $input->getOption('target');
         } elseif ($projectRoot = $this->getProjectRoot()) {
-            $sharedMounts = $mountService->getSharedFileMounts($appConfig);
+            $sharedMounts = $mountService->getSharedFileMounts($mounts);
             if (isset($sharedMounts[$mountPath])) {
                 if (file_exists($projectRoot . '/' . $this->config()->get('local.shared_dir') . '/' . $sharedMounts[$mountPath])) {
                     $defaultTarget = $projectRoot . '/' . $this->config()->get('local.shared_dir') . '/' . $sharedMounts[$mountPath];
@@ -82,7 +82,7 @@ class MountDownloadCommand extends MountCommandBase
             $applications = LocalApplication::getApplications($projectRoot, $this->config());
             $appPath = $projectRoot;
             foreach ($applications as $path => $candidateApp) {
-                if ($candidateApp->getName() === $appName) {
+                if ($candidateApp->getName() === $sshDestination->getName()) {
                     $appPath = $path;
                     break;
                 }
@@ -128,7 +128,7 @@ class MountDownloadCommand extends MountCommandBase
             return 1;
         }
 
-        $this->runSync($appName, $mountPath, $target, false, [
+        $this->runSync($sshDestination->getSshUrl(), $mountPath, $target, false, [
             'delete' => $input->getOption('delete'),
             'exclude' => $input->getOption('exclude'),
             'include' => $input->getOption('include'),

--- a/src/Local/LocalApplication.php
+++ b/src/Local/LocalApplication.php
@@ -170,7 +170,11 @@ class LocalApplication
      */
     public function getSharedFileMounts()
     {
-        return $this->mount->getSharedFileMounts($this->getConfig());
+        $config = $this->getConfig();
+
+        return !empty($config['mounts'])
+            ? $this->mount->getSharedFileMounts($config['mounts'])
+            : [];
     }
 
     /**

--- a/src/Model/SshDestination/App.php
+++ b/src/Model/SshDestination/App.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Platformsh\Cli\Model\SshDestination;
+
+use Platformsh\Cli\Model\AppConfig;
+use Platformsh\Client\Model\Deployment\WebApp;
+use Platformsh\Client\Model\Environment;
+
+class App implements SshDestinationInterface
+{
+    private $webApp;
+    private $environment;
+
+    /**
+     * @param \Platformsh\Client\Model\Deployment\WebApp $webApp
+     * @param \Platformsh\Client\Model\Environment       $environment
+     */
+    public function __construct(WebApp $webApp, Environment $environment) {
+        $this->webApp = $webApp;
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSshUrl()
+    {
+        return $this->environment->getSshUrl($this->webApp->name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->webApp->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'app';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMounts() {
+        $config = AppConfig::fromWebApp($this->webApp)->getNormalized();
+
+        return !empty($config['mounts']) ? $config['mounts'] : [];
+    }
+}

--- a/src/Model/SshDestination/SshDestinationInterface.php
+++ b/src/Model/SshDestination/SshDestinationInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Platformsh\Cli\Model\SshDestination;
+
+/**
+ * Represents a resource that provides an SSH server.
+ */
+interface SshDestinationInterface
+{
+    /**
+     * Returns the destination's SSH URL.
+     *
+     * @return string
+     */
+    public function getSshUrl();
+
+    /**
+     * Returns the destination's name (machine or human-readable).
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Returns the destination type (a human-readable string).
+     *
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * Lists file mounts on the destination.
+     *
+     * @return array
+     *   An associative array of mounts, taken from the configuration in the
+     *   app config file (.platform.app.yaml).
+     */
+    public function getMounts();
+}

--- a/src/Model/SshDestination/Worker.php
+++ b/src/Model/SshDestination/Worker.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Platformsh\Cli\Model\SshDestination;
+
+use Platformsh\Cli\Model\AppConfig;
+use Platformsh\Client\Model\Environment;
+use Platformsh\Client\Model\Deployment\Worker as DeployedWorker;
+
+class Worker implements SshDestinationInterface
+{
+    private $worker;
+    private $environment;
+
+    /**
+     * @param \Platformsh\Client\Model\Deployment\Worker $worker
+     * @param \Platformsh\Client\Model\Environment       $environment
+     */
+    public function __construct(DeployedWorker $worker, Environment $environment) {
+        $this->worker = $worker;
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSshUrl()
+    {
+        return $this->environment->getWorkerSshUrl($this->worker);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->worker->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'worker';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMounts() {
+        $config = (new AppConfig($this->worker->getProperties()))->getNormalized();
+
+        return !empty($config['mounts']) ? $config['mounts'] : [];
+    }
+}

--- a/src/Service/Mount.php
+++ b/src/Service/Mount.php
@@ -11,21 +11,20 @@ class Mount
     /**
      * Get a list of shared file mounts configured for an app.
      *
-     * @param array $appConfig The app configuration.
+     * @param array $mounts An associative array of mounts, taken from the app
+     *                      configuration.
      *
      * @return array
      *   An array of shared file paths, keyed by the mount path. Leading and
      *   trailing slashes are stripped. An empty shared path defaults to
      *   'files'.
      */
-    public function getSharedFileMounts(array $appConfig)
+    public function getSharedFileMounts(array $mounts)
     {
         $sharedFileMounts = [];
-        if (!empty($appConfig['mounts'])) {
-            foreach ($this->normalizeMounts($appConfig['mounts']) as $path => $definition) {
-                if (isset($definition['source_path'])) {
-                    $sharedFileMounts[$path] = $definition['source_path'] ?: 'files';
-                }
+        foreach ($this->normalizeMounts($mounts) as $path => $definition) {
+            if (isset($definition['source_path'])) {
+                $sharedFileMounts[$path] = $definition['source_path'] ?: 'files';
             }
         }
 
@@ -34,6 +33,10 @@ class Mount
 
     /**
      * Normalize a list of mounts.
+     *
+     * This ensures the mount path does not begin or end with a '/', and that
+     * the mount definition is in the newer structured format, with a 'source'
+     * and probably a 'source_path'.
      *
      * @param array $mounts
      *
@@ -50,22 +53,24 @@ class Mount
     }
 
     /**
-     * Validate and normalize a path to a mount.
+     * Checks that a given path matches a mount in the list.
      *
-     * @param string $inputPath
+     * @param string $path
      * @param array  $mounts
      *
+     * @throws \InvalidArgumentException if the path does not match
+     *
      * @return string
-     *   The normalized mount path.
+     *   If the $path matches, the normalized path is returned.
      */
-    public function validateMountPath($inputPath, array $mounts)
+    public function matchMountPath($path, array $mounts)
     {
-        $normalized = $this->normalizeRelativePath($inputPath);
+        $normalized = $this->normalizeRelativePath($path);
         if (isset($mounts[$normalized])) {
             return $normalized;
         }
 
-        throw new \InvalidArgumentException(sprintf('Mount not found: <error>%s</error>', $inputPath));
+        throw new \InvalidArgumentException(sprintf('Mount not found: <error>%s</error>', $path));
     }
 
     /**


### PR DESCRIPTION
Resolves #797

* Adds the `--worker` option to all `mount` commands.
* Adds the `--worker` option to the `environment:logs` (`log`) command.
* Refactors worker selection in the `environment:ssh` (`ssh`) command.
* If `--app` or `--worker` is not provided, the above commands will now prompt the user to choose between the app(s) or their worker(s).
  - The choices are filtered if either the app name or a non-qualified worker name is provided.
  - If there is only one choice available, the prompt is skipped.