### PR TITLE
Pass max_allowed_packet setting to mysqldump

### DIFF
--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -213,6 +213,9 @@ class DbDumpCommand extends CommandBase
                             return OsUtil::escapePosixShellArg($table);
                         }, $includedTables));
                 }
+                if (!empty($service->configuration['properties']['max_allowed_packet'])) {
+                    $dumpCommand .= ' --max_allowed_packet=' . $service->configuration['properties']['max_allowed_packet'] . 'MB';
+                }
                 if ($output->isVeryVerbose()) {
                     $dumpCommand .= ' --verbose';
                 }


### PR DESCRIPTION
I was receiving this error while trying to dump by DB
```
> platform db:dump
Creating SQL dump file: dump.sql
mysqldump: Error 2020: Got packet bigger than 'max_allowed_packet' bytes when dumping table `cache_render` at row: 1024
```
max_allowed_packet is set in the DB service config but it isn't passed on to mysqldump. This patch passes the setting on and allows my dump to succeed