### PR TITLE
Accept wholly indented YAML files

### DIFF
--- a/tests/Util/YamlParserTest.php
+++ b/tests/Util/YamlParserTest.php
@@ -38,4 +38,24 @@ class YamlParserTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(InvalidConfigException::class, 'File not found');
         (new YamlParser())->parseContent($content, $file);
     }
+
+    public function testParseIndentedYaml()
+    {
+        $file = 'example.yaml';
+        $content = <<<EOF
+
+  name: example-indented-yaml
+  key: value
+
+  foo:
+    nested: bar
+EOF;
+;
+        $result = (new YamlParser())->parseContent($content, $file);
+        $this->assertEquals([
+            'name' => 'example-indented-yaml',
+            'key' => 'value',
+            'foo' => ['nested' => 'bar'],
+        ], $result);
+    }
 }


### PR DESCRIPTION
The Symfony YAML parser doesn't handle this itself.

Apparently indenting the whole file is helpful for included files. It doesn't seem to be forbidden in the YAML spec, in fact the spec insists

> The amount of indentation is a presentation detail and must not be used to convey content information.