### PR TITLE
Add helpers to decode environment variables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.22 <2.0",
-        "platformsh/client": ">=0.26.0 <2.0",
+        "platformsh/client": ">=0.27.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9c16964bacb0c8efa07ccc991a7437d",
+    "content-hash": "c1ff0b9b2fc1425569ea1ea6f811defa",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -663,16 +663,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "v0.26.0",
+            "version": "v0.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "b6cb469386ab5e986ba729c0355aaa388597364d"
+                "reference": "317b4db1bddc86dfa63376fc92bd9c98cab78c38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/b6cb469386ab5e986ba729c0355aaa388597364d",
-                "reference": "b6cb469386ab5e986ba729c0355aaa388597364d",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/317b4db1bddc86dfa63376fc92bd9c98cab78c38",
+                "reference": "317b4db1bddc86dfa63376fc92bd9c98cab78c38",
                 "shasum": ""
             },
             "require": {
@@ -702,7 +702,7 @@
                 }
             ],
             "description": "Platform.sh API client",
-            "time": "2019-06-04T13:40:55+00:00"
+            "time": "2019-06-12T08:13:33+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Application.php
+++ b/src/Application.php
@@ -198,6 +198,7 @@ class Application extends ParentApplication
         $commands[] = new Command\User\UserGetCommand();
         $commands[] = new Command\User\UserUpdateCommand();
         $commands[] = new Command\Variable\VariableCreateCommand();
+        $commands[] = new Command\Variable\VariableDecodeCommand();
         $commands[] = new Command\Variable\VariableDeleteCommand();
         $commands[] = new Command\Variable\VariableDisableCommand();
         $commands[] = new Command\Variable\VariableEnableCommand();

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1507,4 +1507,30 @@ abstract class CommandBase extends Command implements MultiAwareInterface
 
         return $description;
     }
+
+    /**
+     * @return bool
+     */
+    protected function doesEnvironmentConflictWithCommandLine(InputInterface $input) {
+        $envPrefix = $this->config()->get('service.env_prefix');
+        if ($input->hasOption('project')
+            && $input->getOption('project')
+            && getenv($envPrefix . 'PROJECT')
+            && getenv($envPrefix . 'PROJECT') !== $input->getOption('project')) {
+            return true;
+        }
+        if ($input->hasOption('environment')
+            && $input->getOption('environment')
+            && getenv($envPrefix . 'BRANCH')
+            && getenv($envPrefix . 'BRANCH') !== $input->getOption('environment')) {
+            return true;
+        }
+        if ($input->hasOption('app') && $input->getOption('app')
+            && getenv($envPrefix . 'APPLICATION_NAME')
+            && getenv($envPrefix . 'APPLICATION_NAME') !== $input->getOption('app')) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Command/Route/RouteGetCommand.php
+++ b/src/Command/Route/RouteGetCommand.php
@@ -60,7 +60,7 @@ class RouteGetCommand extends CommandBase
         $id = $input->getOption('id');
         if (!$selectedRoute && $id !== null) {
             foreach ($routes as $route) {
-                if (isset($route->id) && $route->id === $id) {
+                if ($route->id === $id) {
                     $selectedRoute = $route;
                     break;
                 }
@@ -74,7 +74,7 @@ class RouteGetCommand extends CommandBase
 
         if (!$selectedRoute && $input->getOption('primary')) {
             foreach ($routes as $route) {
-                if (!empty($route->primary)) {
+                if ($route->primary) {
                     $selectedRoute = $route;
                     break;
                 }
@@ -100,7 +100,7 @@ class RouteGetCommand extends CommandBase
                 if (!empty($route->id)) {
                     $items[$originalUrl] .= ' (<info>' . $route->id . '</info>)';
                 }
-                if (!empty($route->primary)) {
+                if ($route->primary) {
                     $items[$originalUrl] .= ' - <info>primary</info>';
                 }
             }
@@ -131,7 +131,6 @@ class RouteGetCommand extends CommandBase
 
         // Add defaults.
         $selectedRoute = $selectedRoute->getProperties();
-        $selectedRoute += ['primary' => false, 'id' => null];
 
         /** @var PropertyFormatter $propertyFormatter */
         $propertyFormatter = $this->getService('property_formatter');

--- a/src/Command/Route/RouteGetCommand.php
+++ b/src/Command/Route/RouteGetCommand.php
@@ -3,6 +3,7 @@ namespace Platformsh\Cli\Command\Route;
 
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Service\PropertyFormatter;
+use Platformsh\Client\Model\Route;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -31,23 +32,62 @@ class RouteGetCommand extends CommandBase
         $this->addExample('View the URL to the https://{default}/ route', "'https://{default}/' -P url");
     }
 
+    /**
+     * @return bool
+     */
+    private function isLocalOnContainer(InputInterface $input) {
+        $envPrefix = $this->config()->get('service.env_prefix');
+        if ($input->getOption('project')
+            && getenv($envPrefix . 'PROJECT')
+            && getenv($envPrefix . 'PROJECT') !== $input->getOption('project')) {
+            return false;
+        }
+        if ($input->getOption('environment')
+            && getenv($envPrefix . 'BRANCH')
+            && getenv($envPrefix . 'BRANCH') !== $input->getOption('environment')) {
+            return false;
+        }
+        if ($input->getOption('app')
+            && getenv($envPrefix . 'APPLICATION_NAME')
+            && getenv($envPrefix . 'APPLICATION_NAME') !== $input->getOption('app')) {
+            return false;
+        }
+
+        return true;
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->validateInput($input);
+        // Allow override via PLATFORM_ROUTES.
+        $prefix = $this->config()->get('service.env_prefix');
+        if (getenv($prefix . 'ROUTES') && $this->isLocalOnContainer($input)) {
+            $decoded = json_decode(base64_decode(getenv($prefix . 'ROUTES'), true), true);
+            if (empty($decoded)) {
+                throw new \RuntimeException('Failed to decode: ' . $prefix . 'ROUTES');
+            }
+            $routes = $decoded;
+        } else {
+            $this->validateInput($input);
+            $environment = $this->getSelectedEnvironment();
+            $deployment = $this->api()
+                ->getCurrentDeployment($environment, $input->getOption('refresh'));
+            $routes = array_map(function (Route $route) {
+                return $route->getProperties();
+            }, $deployment->routes);
+        }
+
         $this->warnAboutDeprecatedOptions(['app', 'identity-file']);
 
-        $environment = $this->getSelectedEnvironment();
-
-        $routes = $this->api()->getCurrentDeployment($environment, $input->getOption('refresh'))->routes;
-
+        /** @var array|false $selectedRoute */
         $selectedRoute = false;
+
         $id = $input->getOption('id');
         if (!$selectedRoute && $id !== null) {
             foreach ($routes as $url => $route) {
-                $properties = $route->getProperties();
-                if (isset($properties['id']) && $properties['id'] === $id) {
-                    $selectedRoute = $properties;
+                if (isset($route['id']) && $route['id'] === $id) {
+                    $selectedRoute = $route;
                     $selectedRoute['url'] = $url;
+                    break;
                 }
             }
             if (!$selectedRoute) {
@@ -59,10 +99,10 @@ class RouteGetCommand extends CommandBase
 
         if (!$selectedRoute && $input->getOption('primary')) {
             foreach ($routes as $url => $route) {
-                $properties = $route->getProperties();
-                if (isset($properties['primary']) && $properties['primary']) {
-                    $selectedRoute = $properties;
+                if (!empty($route['primary'])) {
+                    $selectedRoute = $route;
                     $selectedRoute['url'] = $url;
+                    break;
                 }
             }
             if (!$selectedRoute) {
@@ -83,10 +123,10 @@ class RouteGetCommand extends CommandBase
             foreach ($routes as $route) {
                 $originalUrl = $route->original_url;
                 $items[$originalUrl] = $originalUrl;
-                if (!empty($route->id)) {
-                    $items[$originalUrl] .= ' (<info>' . $route->id . '</info>)';
+                if (!empty($route['id'])) {
+                    $items[$originalUrl] .= ' (<info>' . $route['id'] . '</info>)';
                 }
-                if (!empty($route->primary)) {
+                if (!empty($route['primary'])) {
                     $items[$originalUrl] .= ' - <info>primary</info>';
                 }
             }
@@ -96,8 +136,8 @@ class RouteGetCommand extends CommandBase
 
         if (!$selectedRoute && $originalUrl !== null) {
             foreach ($routes as $url => $route) {
-                if ($route->original_url === $originalUrl) {
-                    $selectedRoute = $route->getProperties();
+                if (isset($route['original_url']) && $route['original_url'] === $originalUrl) {
+                    $selectedRoute = $route;
                     $selectedRoute['url'] = $url;
                     break;
                 }
@@ -115,6 +155,9 @@ class RouteGetCommand extends CommandBase
 
             return 1;
         }
+
+        // Add defaults.
+        $selectedRoute += ['primary' => false, 'id' => null];
 
         /** @var PropertyFormatter $propertyFormatter */
         $propertyFormatter = $this->getService('property_formatter');

--- a/src/Command/Route/RouteGetCommand.php
+++ b/src/Command/Route/RouteGetCommand.php
@@ -2,8 +2,8 @@
 namespace Platformsh\Cli\Command\Route;
 
 use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Model\Route;
 use Platformsh\Cli\Service\PropertyFormatter;
-use Platformsh\Client\Model\Route;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -32,61 +32,36 @@ class RouteGetCommand extends CommandBase
         $this->addExample('View the URL to the https://{default}/ route', "'https://{default}/' -P url");
     }
 
-    /**
-     * @return bool
-     */
-    private function isLocalOnContainer(InputInterface $input) {
-        $envPrefix = $this->config()->get('service.env_prefix');
-        if ($input->getOption('project')
-            && getenv($envPrefix . 'PROJECT')
-            && getenv($envPrefix . 'PROJECT') !== $input->getOption('project')) {
-            return false;
-        }
-        if ($input->getOption('environment')
-            && getenv($envPrefix . 'BRANCH')
-            && getenv($envPrefix . 'BRANCH') !== $input->getOption('environment')) {
-            return false;
-        }
-        if ($input->getOption('app')
-            && getenv($envPrefix . 'APPLICATION_NAME')
-            && getenv($envPrefix . 'APPLICATION_NAME') !== $input->getOption('app')) {
-            return false;
-        }
-
-        return true;
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // Allow override via PLATFORM_ROUTES.
         $prefix = $this->config()->get('service.env_prefix');
-        if (getenv($prefix . 'ROUTES') && $this->isLocalOnContainer($input)) {
+        if (getenv($prefix . 'ROUTES') && !$this->doesEnvironmentConflictWithCommandLine($input)) {
+            $this->debug('Reading routes from environment variable ' . $prefix . 'ROUTES');
             $decoded = json_decode(base64_decode(getenv($prefix . 'ROUTES'), true), true);
             if (empty($decoded)) {
                 throw new \RuntimeException('Failed to decode: ' . $prefix . 'ROUTES');
             }
-            $routes = $decoded;
+            $routes = Route::fromVariables($decoded);
         } else {
+            $this->debug('Reading routes from the API');
             $this->validateInput($input);
             $environment = $this->getSelectedEnvironment();
             $deployment = $this->api()
                 ->getCurrentDeployment($environment, $input->getOption('refresh'));
-            $routes = array_map(function (Route $route) {
-                return $route->getProperties();
-            }, $deployment->routes);
+            $routes = Route::fromDeploymentApi($deployment->routes);
         }
 
         $this->warnAboutDeprecatedOptions(['app', 'identity-file']);
 
-        /** @var array|false $selectedRoute */
+        /** @var \Platformsh\Cli\Model\Route|false $selectedRoute */
         $selectedRoute = false;
 
         $id = $input->getOption('id');
         if (!$selectedRoute && $id !== null) {
-            foreach ($routes as $url => $route) {
-                if (isset($route['id']) && $route['id'] === $id) {
+            foreach ($routes as $route) {
+                if (isset($route->id) && $route->id === $id) {
                     $selectedRoute = $route;
-                    $selectedRoute['url'] = $url;
                     break;
                 }
             }
@@ -98,10 +73,9 @@ class RouteGetCommand extends CommandBase
         }
 
         if (!$selectedRoute && $input->getOption('primary')) {
-            foreach ($routes as $url => $route) {
-                if (!empty($route['primary'])) {
+            foreach ($routes as $route) {
+                if (!empty($route->primary)) {
                     $selectedRoute = $route;
-                    $selectedRoute['url'] = $url;
                     break;
                 }
             }
@@ -111,7 +85,7 @@ class RouteGetCommand extends CommandBase
         }
 
         $originalUrl = $input->getArgument('route');
-        if (!$selectedRoute && $originalUrl === null) {
+        if (!$selectedRoute && ($originalUrl === null || $originalUrl === '')) {
             if (!$input->isInteractive()) {
                 $this->stdErr->writeln('You must specify a route via the <comment>route</comment> argument or <comment>--id</comment> option.');
 
@@ -123,10 +97,10 @@ class RouteGetCommand extends CommandBase
             foreach ($routes as $route) {
                 $originalUrl = $route->original_url;
                 $items[$originalUrl] = $originalUrl;
-                if (!empty($route['id'])) {
-                    $items[$originalUrl] .= ' (<info>' . $route['id'] . '</info>)';
+                if (!empty($route->id)) {
+                    $items[$originalUrl] .= ' (<info>' . $route->id . '</info>)';
                 }
-                if (!empty($route['primary'])) {
+                if (!empty($route->primary)) {
                     $items[$originalUrl] .= ' - <info>primary</info>';
                 }
             }
@@ -134,11 +108,10 @@ class RouteGetCommand extends CommandBase
             $originalUrl = $questionHelper->choose($items, 'Enter a number to choose a route:');
         }
 
-        if (!$selectedRoute && $originalUrl !== null) {
-            foreach ($routes as $url => $route) {
-                if (isset($route['original_url']) && $route['original_url'] === $originalUrl) {
+        if (!$selectedRoute && $originalUrl !== null && $originalUrl !== '') {
+            foreach ($routes as $route) {
+                if ($route->original_url === $originalUrl) {
                     $selectedRoute = $route;
-                    $selectedRoute['url'] = $url;
                     break;
                 }
             }
@@ -157,6 +130,7 @@ class RouteGetCommand extends CommandBase
         }
 
         // Add defaults.
+        $selectedRoute = $selectedRoute->getProperties();
         $selectedRoute += ['primary' => false, 'id' => null];
 
         /** @var PropertyFormatter $propertyFormatter */

--- a/src/Command/Route/RouteListCommand.php
+++ b/src/Command/Route/RouteListCommand.php
@@ -3,6 +3,7 @@ namespace Platformsh\Cli\Command\Route;
 
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
+use Platformsh\Cli\Model\Route;
 use Platformsh\Cli\Service\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,11 +29,23 @@ class RouteListCommand extends CommandBase
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->validateInput($input);
-
-        $environment = $this->getSelectedEnvironment();
-
-        $routes = $environment->getRoutes();
+        // Allow override via PLATFORM_ROUTES.
+        $prefix = $this->config()->get('service.env_prefix');
+        if (getenv($prefix . 'ROUTES') && !$this->doesEnvironmentConflictWithCommandLine($input)) {
+            $this->debug('Reading routes from environment variable ' . $prefix . 'ROUTES');
+            $decoded = json_decode(base64_decode(getenv($prefix . 'ROUTES'), true), true);
+            if (empty($decoded)) {
+                throw new \RuntimeException('Failed to decode: ' . $prefix . 'ROUTES');
+            }
+            $routes = Route::fromVariables($decoded);
+            $fromEnv = true;
+        } else {
+            $this->debug('Reading routes from the API');
+            $this->validateInput($input);
+            $environment = $this->getSelectedEnvironment();
+            $routes = Route::fromEnvironmentApi($environment->getRoutes());
+            $fromEnv = false;
+        }
         if (empty($routes)) {
             $this->stdErr->writeln("No routes found");
 
@@ -46,18 +59,23 @@ class RouteListCommand extends CommandBase
         $rows = [];
         foreach ($routes as $route) {
             $rows[] = [
-                new AdaptiveTableCell($route->id, ['wrap' => false]),
+                new AdaptiveTableCell($route->original_url, ['wrap' => false]),
                 $route->type,
                 $route->type == 'upstream' ? $route->upstream : $route->to,
             ];
         }
 
         if (!$table->formatIsMachineReadable()) {
-            $this->stdErr->writeln(sprintf(
-                'Routes on the project %s, environment %s:',
-                $this->api()->getProjectLabel($this->getSelectedProject()),
-                $this->api()->getEnvironmentLabel($environment)
-            ));
+            if ($fromEnv) {
+                $this->stdErr->writeln('Routes in the <info>' . $prefix . 'ROUTES</info> environment variable:');
+            }
+            if (isset($environment) && !$fromEnv) {
+                $this->stdErr->writeln(sprintf(
+                    'Routes on the project %s, environment %s:',
+                    $this->api()->getProjectLabel($this->getSelectedProject()),
+                    $this->api()->getEnvironmentLabel($environment)
+                ));
+            }
         }
 
         $table->render($rows, $header);

--- a/src/Command/Variable/VariableDecodeCommand.php
+++ b/src/Command/Variable/VariableDecodeCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Platformsh\Cli\Command\Variable;
+
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Util\NestedArrayUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class VariableDecodeCommand extends CommandBase
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('variable:decode')
+            ->addArgument('value', InputArgument::REQUIRED, 'The variable value to decode')
+            ->addOption('path', 'P', InputOption::VALUE_REQUIRED, 'The path to view within the variable')
+            ->setDescription('Decode a complex environment variable');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $variable = $input->getArgument('value');
+
+        $decoded = json_decode(base64_decode($variable, true), true);
+        if (empty($decoded)) {
+            $message = 'Failed to decode variable';
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $message .= ":\n" . json_last_error_msg();
+            }
+            throw new \RuntimeException($message);
+        }
+
+        if ($path = $input->getOption('path')) {
+            $value = NestedArrayUtil::getNestedArrayValue($decoded, explode('.', $path), $keyExists);
+            if (!$keyExists) {
+                throw new \RuntimeException('Path not found: <error>' . $path . '</error>');
+            }
+        } else {
+            $value = $decoded;
+        }
+
+        if (is_string($value)) {
+            $output->writeln($value);
+        } else {
+            $output->writeln(json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        }
+
+        return 0;
+    }
+}

--- a/src/Model/Route.php
+++ b/src/Model/Route.php
@@ -5,14 +5,21 @@ namespace Platformsh\Cli\Model;
 use Platformsh\Client\DataStructure\ReadOnlyStructureTrait;
 
 /**
- * @property-read string $original_url
- * @property-read string $type
- * @property-read string $upstream
- * @property-read string $to
+ * @property-read string      $original_url
+ * @property-read string      $type
+ * @property-read string      $upstream
+ * @property-read string      $to
+ * @property-read bool        $primary
+ * @property-read string|null $id
+ * @property-read string      $url
  */
 class Route
 {
     use ReadOnlyStructureTrait;
+
+    public static function fromData(array $data) {
+        return new static($data + ['id' => null, 'primary' => false]);
+    }
 
     /**
      * Translates routes found in $environment->getRoutes() to Route objects.

--- a/src/Model/Route.php
+++ b/src/Model/Route.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Platformsh\Cli\Model;
+
+use Platformsh\Client\DataStructure\ReadOnlyStructureTrait;
+
+/**
+ * @property-read string $original_url
+ * @property-read string $type
+ * @property-read string $upstream
+ * @property-read string $to
+ */
+class Route
+{
+    use ReadOnlyStructureTrait;
+
+    /**
+     * Translates routes found in $environment->getRoutes() to Route objects.
+     *
+     * @see \Platformsh\Client\Model\Environment::getRoutes()
+     *
+     * @param \Platformsh\Client\Model\Deployment\Route[] $routes
+     *
+     * @return \Platformsh\Cli\Model\Route[]
+     */
+    public static function fromDeploymentApi(array $routes)
+    {
+        $result = [];
+        foreach ($routes as $url => $route) {
+            $properties = $route->getProperties();
+            $properties['url'] = $url;
+            $result[] = static::fromData($properties);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Translates routes found in $environment->getRoutes() to Route objects.
+     *
+     * @see \Platformsh\Client\Model\Environment::getRoutes()
+     *
+     * @param \Platformsh\Client\Model\Route[] $routes
+     *
+     * @return \Platformsh\Cli\Model\Route[]
+     */
+    public static function fromEnvironmentApi(array $routes)
+    {
+        $result = [];
+        foreach ($routes as $url => $route) {
+            $properties = $route->getProperties();
+            $properties['original_url'] = $properties['id'];
+            $properties['url'] = $url;
+            unset($properties['id']);
+            $result[] = static::fromData($properties);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Translates routes found in PLATFORM_ROUTES to Route objects.
+     *
+     * @param array $routes
+     *
+     * @return \Platformsh\Cli\Model\Route[]
+     */
+    public static function fromVariables(array $routes)
+    {
+        $result = [];
+
+        foreach ($routes as $url => $route) {
+            $route['url'] = $url;
+            $result[] = static::fromData($route);
+        }
+
+        return $result;
+    }
+}

--- a/tests/Command/Environment/EnvironmentRelationshipsTest.php
+++ b/tests/Command/Environment/EnvironmentRelationshipsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Platformsh\Cli\Tests\Command\Helper;
+
+use Platformsh\Cli\Command\Environment\EnvironmentRelationshipsCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class EnvironmentRelationshipsTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp() {
+        $mockRelationships = base64_encode(json_encode([
+            'database' => [
+                0 => [
+                    'host' => 'database.internal',
+                    'username' => 'main',
+                    'password' => '123',
+                    'scheme' => 'mysql',
+                    'path' => 'main',
+                    'port' => 3306,
+                    'rel' => 'mysql',
+                    'service' => 'database',
+                    'query' => ['is_master' => true],
+                ]
+            ],
+        ]));
+        putenv('PLATFORM_RELATIONSHIPS=' . $mockRelationships);
+    }
+
+    public function tearDown() {
+        putenv('PLATFORM_RELATIONSHIPS=');
+    }
+
+    private function runCommand(array $args) {
+        $output = new BufferedOutput();
+        (new EnvironmentRelationshipsCommand())
+            ->run(new ArrayInput($args), $output);
+
+        return $output->fetch();
+    }
+
+    public function testGetRelationshipHost() {
+        $this->assertEquals(
+            'database.internal',
+            rtrim($this->runCommand([
+                '--property' => 'database.0.host',
+            ]), "\n")
+        );
+    }
+
+    public function testGetRelationshipUrl() {
+        $this->assertEquals(
+            'mysql://main:123@database.internal:3306/main?is_master=1',
+            rtrim($this->runCommand([
+                '--property' => 'database.0.url',
+            ]), "\n")
+        );
+    }
+}

--- a/tests/Command/Route/RouteGetTest.php
+++ b/tests/Command/Route/RouteGetTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Platformsh\Cli\Tests\Command\Helper;
+
+use Platformsh\Cli\Command\Route\RouteGetCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class RouteGetTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp() {
+        $mockRoutes = base64_encode(json_encode([
+            'https://example.com' => [
+                'primary' => true,
+                'type' => 'upstream',
+                'upstream' => 'app:http',
+                'original_url' => 'https://{default}',
+            ],
+            'http://example.com' => [
+                'type' => 'redirect',
+                'to' => 'https://example.com',
+                'original_url' => 'http://{default}',
+            ],
+        ]));
+        putenv('PLATFORM_ROUTES=' . $mockRoutes);
+    }
+
+    public function tearDown() {
+        putenv('PLATFORM_ROUTES=');
+    }
+
+    private function runCommand(array $args) {
+        $output = new BufferedOutput();
+        (new RouteGetCommand())
+            ->run(new ArrayInput($args), $output);
+
+        return $output->fetch();
+    }
+
+    public function testGetPrimaryRouteUrl() {
+        $this->assertEquals(
+            'https://example.com',
+            rtrim($this->runCommand([
+                '--primary' => true,
+                '--property' => 'url',
+            ]), "\n")
+        );
+    }
+
+    public function testGetRouteByOriginalUrl() {
+        $this->assertEquals(
+            'false',
+            rtrim($this->runCommand([
+                'route' => 'http://{default}',
+                '--property' => 'primary',
+            ]), "\n")
+        );
+        $this->assertEquals(
+            'true',
+            rtrim($this->runCommand([
+                'route' => 'https://{default}',
+                '--property' => 'primary',
+            ]), "\n")
+        );
+    }
+}

--- a/tests/Command/Route/RouteListTest.php
+++ b/tests/Command/Route/RouteListTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Platformsh\Cli\Tests\Command\Helper;
+
+use Platformsh\Cli\Command\Route\RouteListCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class RouteListTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp() {
+        $mockRoutes = base64_encode(json_encode([
+            'https://example.com' => [
+                'primary' => true,
+                'type' => 'upstream',
+                'upstream' => 'app:http',
+                'original_url' => 'https://{default}',
+            ],
+            'http://example.com' => [
+                'type' => 'redirect',
+                'to' => 'https://{default}',
+                'original_url' => 'http://{default}',
+            ],
+        ]));
+        putenv('PLATFORM_ROUTES=' . $mockRoutes);
+    }
+
+    public function tearDown() {
+        putenv('PLATFORM_ROUTES=');
+    }
+
+    private function runCommand(array $args) {
+        $output = new BufferedOutput();
+        (new RouteListCommand())
+            ->run(new ArrayInput($args), $output);
+
+        return $output->fetch();
+    }
+
+    public function testListRoutes() {
+        $this->assertEquals(
+            "https://{default}\tupstream\tapp:http\n"
+            . "http://{default}\tredirect\thttps://{default}\n",
+            $this->runCommand([
+                '--format' => 'tsv',
+                '--columns' => ['route,type,to'],
+                '--no-header' => true,
+            ])
+        );
+    }
+}

--- a/tests/Command/Variable/VariableDecodeTest.php
+++ b/tests/Command/Variable/VariableDecodeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Platformsh\Cli\Tests\Command\Helper;
+
+use Platformsh\Cli\Command\Variable\VariableDecodeCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class VariableDecodeTest extends \PHPUnit_Framework_TestCase
+{
+    private function runCommand(array $args) {
+        $output = new BufferedOutput();
+        (new VariableDecodeCommand())
+            ->run(new ArrayInput($args), $output);
+
+        return $output->fetch();
+    }
+
+    public function testDecode() {
+        $var = base64_encode(json_encode([
+            'foo' => 'bar',
+            'fee' => 'bor',
+            'nest' => ['nested' => 'baz'],
+        ]));
+        $this->assertEquals(
+            'bar',
+            rtrim($this->runCommand([
+                'value' => $var,
+                '--path' => 'foo',
+            ]), "\n")
+        );
+        $this->assertEquals(
+            'baz',
+            rtrim($this->runCommand([
+                'value' => $var,
+                '--path' => 'nest.nested',
+            ]), "\n")
+        );
+    }
+}


### PR DESCRIPTION
- [x] Makes the following commands work "locally" when variables such as PLATFORM_ROUTES are 
set. Simplicity for the end user at the expense of a little code complexity.
    - [x] route:get
    - [x] route:list
    - [x] environment:relationships
- [x] add variable:decode command (e.g. `p v:decode "$PLATFORM_VARIABLES" -P myvar`)