### PR TITLE
Show usage per database.

### DIFF
--- a/src/Command/Db/DbSizeCommand.php
+++ b/src/Command/Db/DbSizeCommand.php
@@ -55,7 +55,6 @@ class DbSizeCommand extends CommandBase
         }
 
         if (!isset($database['service'])) {
-            $this->stdErr->writeln(print_r($database, true));
             $this->stdErr->writeln('Unable to find database service information.');
             return 1;
         }
@@ -269,13 +268,11 @@ class DbSizeCommand extends CommandBase
         $relationships = $this->getService('relationships');
         $connectionParams = $relationships->getDbCommandArgs('mysql', $database, '');
 
-        $return =sprintf(
+        return sprintf(
             "mysql %s --no-auto-rehash --raw --skip-column-names --execute '%s'",
             $connectionParams,
             $query
         );
-
-        return $return;
     }
 
     /**


### PR DESCRIPTION
Customer reported a bug in the new version. That caused him to see the same numbers for every database/relation. I had to add a new table to show the database sizes because we can't directly compare that against the allocated size. 
On the bright side: this does make it very clear where the storage usage is coming from.

![image](https://user-images.githubusercontent.com/3532563/60268199-257a8100-98ec-11e9-9591-6bcb2a959a2f.png)
