### PR TITLE
Installer: require curl, openssl and pcre

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -20,6 +20,18 @@ hooks:
     EOF
 
     mv dist/dev-build-index.php web/index.php
+    mv dist/installer.php web/installer
+    export sha256="$(sha256sum web/platform.phar | cut -f1 -d' ')"
+    cat <<EOF > web/manifest.json
+    [
+      {
+        "version": "$version",
+        "sha256": "$sha256",
+        "name": "platform.phar",
+        "url": "platform.phar"
+      }
+    ]
+    EOF
 
 web:
   locations:

--- a/dist/dev-build-index.php
+++ b/dist/dev-build-index.php
@@ -37,6 +37,12 @@ if ($config->has('application.github_repo')) {
     $sourceLinkSpecific = false;
 }
 
+$appEnvPrefix = $config->get('application.env_prefix');
+$baseUrl = 'https://' . $_SERVER['HTTP_HOST'];
+$installScript = 'export ' . $appEnvPrefix . 'MANIFEST_URL=' . $baseUrl . '/manifest.json;';
+$installScript .= "\n" . 'curl -sS ' . $baseUrl . '/installer | php -- --dev;';
+$installScript .= "\n" . 'unset ' . $appEnvPrefix . 'MANIFEST_URL;';
+
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -72,6 +78,11 @@ if ($config->has('application.github_repo')) {
             max-width: 40em;
             margin: 1em auto;
             word-break: break-all;
+        }
+
+        pre {
+            max-width: 60em;
+            margin: 1em auto;
         }
 
         img {
@@ -123,6 +134,14 @@ if ($config->has('application.github_repo')) {
         <p>
             Source: <a href="<?= htmlspecialchars($sourceLinkSpecific) ?>"><?= htmlspecialchars($sourceLinkSpecific) ?></a>
         </p>
+    <?php endif; ?>
+    <?php if ($installScript): ?>
+        <p>
+            Install with:
+        </p>
+<pre>
+<?= htmlspecialchars($installScript) ?>
+</pre>
     <?php endif; ?>
 
 </body>

--- a/dist/installer.php
+++ b/dist/installer.php
@@ -65,6 +65,10 @@ class Installer {
      * Runs the install itself.
      */
     public function run() {
+        error_reporting(E_ALL);
+        ini_set('log_errors', 0);
+        ini_set('display_errors', 1);
+
         $this->output($this->cliName . " installer", 'heading');
 
         // Run environment checks.
@@ -175,17 +179,91 @@ class Installer {
         // The necessary checks have passed. Start downloading the right version.
         $this->output(PHP_EOL . 'Download', 'heading');
 
-        $this->output('  Finding the latest version...');
-        $manifest = file_get_contents($this->manifestUrl);
-        if ($manifest === false) {
-            $this->output('  Failed to download manifest file: ' . $this->manifestUrl, 'error');
-            exit(1);
+        $latest = $this->performTask('Finding the latest version', function () {
+            return $this->findLatestVersion($this->manifestUrl);
+        });
+
+        $this->performTask('Downloading version ' . $latest['version'], function () use ($latest) {
+            if (!file_put_contents($this->pharName, file_get_contents($latest['url']))) {
+                return TaskResult::failure('The download failed');
+            }
+
+            return TaskResult::success();
+        });
+
+        $pharPath = realpath($this->pharName) ?: $this->pharName;
+
+        $this->performTask('Checking file integrity', function () use ($latest, $pharPath) {
+            if ($latest['sha256'] !== hash_file('sha256', $pharPath)) {
+                unlink($pharPath);
+
+                return TaskResult::failure('The download was incomplete, or the file is corrupted');
+            }
+
+            return TaskResult::success();
+        });
+
+        $this->performTask('Checking that the file is a valid Phar', function () use ($pharPath) {
+            try {
+                new \Phar($pharPath);
+            } catch (\Exception $e) {
+                return TaskResult::failure(
+                    'The file is not a valid Phar archive' . "\n" . $e->getMessage()
+                );
+            }
+
+            return TaskResult::success();
+        });
+
+        $this->output(PHP_EOL . 'Install', 'heading');
+
+        $this->performTask('Making the Phar executable', function () use ($pharPath) {
+            if (!chmod($pharPath, 0755)) {
+                return TaskResult::failure('Failed to make the Phar executable');
+            }
+
+            return TaskResult::success();
+        });
+
+        if ($homeDir = $this->getHomeDirectory()) {
+            $pharPath = $this->performTask('Moving the Phar to your home directory', function () use ($pharPath, $homeDir) {
+                $binDir = $homeDir . '/' . $this->configDir . '/bin';
+                if (!is_dir($binDir) && !mkdir($binDir, 0700, true)) {
+                    return TaskResult::failure('Failed to create directory: ' . $binDir);
+                }
+
+                $destination = $binDir . '/' . $this->executable;
+                if (!rename($pharPath, $destination)) {
+                    return TaskResult::failure('Failed to move the Phar to: ' . $destination);
+                }
+
+                return TaskResult::success($destination);
+            });
+            $this->output('  Executable location: ' . $pharPath);
         }
 
+        $this->output(PHP_EOL . 'Running self:install command...' . PHP_EOL);
+        putenv('CLICOLOR_FORCE=' . ($this->terminalSupportsAnsi() ? '1' : '0'));
+        $result = $this->runCommand('php ' . $pharPath . ' self:install --yes');
+
+        exit($result);
+    }
+
+    /**
+     * Finds the latest version to download from the manifest.
+     *
+     * @param string $manifestUrl
+     *
+     * @return TaskResult
+     */
+    private function findLatestVersion($manifestUrl) {
+        $manifest = file_get_contents($manifestUrl);
+        if ($manifest === false) {
+            return TaskResult::failure('Failed to download manifest file: ' . $manifestUrl);
+        }
         $manifest = json_decode($manifest, true);
         if ($manifest === null) {
-            $this->output('  Failed to decode manifest file: ' . $this->manifestUrl, 'error');
-            exit(1);
+            return TaskResult::failure('Failed to decode manifest file: ' . $manifestUrl);
         }
 
         $allowedSuffixes = ['stable'];
@@ -198,67 +276,38 @@ class Installer {
         $resolver = new VersionResolver();
         $versions = $resolver->findInstallableVersions($manifest, $phpVersion, $allowedSuffixes);
         if (empty($versions)) {
-            $this->output('  ' . $resolver->explainNoInstallableVersions($manifest, $phpVersion, $allowedSuffixes), 'error');
-            exit(1);
+            return TaskResult::failure($resolver->explainNoInstallableVersions($manifest, $phpVersion, $allowedSuffixes));
         }
         try {
             $latest = $resolver->findLatestVersion($versions, $this->getOption('min'), $this->getOption('max'));
         } catch (\Exception $e) {
-            $this->output('  ' . $e->getMessage(), 'error');
+            return TaskResult::failure($e->getMessage());
+        }
+
+        return TaskResult::success($latest);
+    }
+
+    /**
+     * @param string   $summaryText Description of the task.
+     * @param callable $task        A function that returns a TaskResult.
+     * @param string   $indent      Whether to indent the summary & errors.
+     *
+     * @return mixed The result of the task, if any.
+     */
+    private function performTask($summaryText, $task, $indent = '  ') {
+        $this->output($indent . $summaryText . '...', null, false);
+        /** @var TaskResult $result */
+        $result = $task();
+        if (!$result->isSuccess()) {
+            $this->output('');
+            if ($message = $result->getMessage()) {
+                $this->output('Error: ' . $message, 'error');
+            }
             exit(1);
         }
+        $this->output(' done', 'success');
 
-        $this->output("  Downloading version {$latest['version']}...");
-        if (!file_put_contents($this->pharName, file_get_contents($latest['url']))) {
-            $this->output('  The download failed.', 'error');
-        }
-
-        $pharPath = realpath($this->pharName) ?: $this->pharName;
-
-        $this->output('  Checking file integrity...');
-        if ($latest['sha256'] !== hash_file('sha256', $pharPath)) {
-            unlink($pharPath);
-            $this->output('  The download was corrupted.', 'error');
-            exit(1);
-        }
-
-        $this->output('  Checking that the file is a valid Phar (PHP Archive)...');
-
-        try {
-            new \Phar($pharPath);
-        } catch (\Exception $e) {
-            $this->output('  The file is not a valid Phar archive.', 'error');
-            $this->output('  ' . $e->getMessage(), 'error');
-            exit(1);
-        }
-
-        $this->output(PHP_EOL . 'Install', 'heading');
-
-        $this->output('  Making the Phar executable...');
-        if (!chmod($pharPath, 0755)) {
-            $this->output('  Failed to make the Phar executable: ' . $pharPath, 'warning');
-        }
-
-        if ($homeDir = $this->getHomeDirectory()) {
-            $this->output('  Moving the Phar to your home directory...');
-            $binDir = $homeDir . '/' . $this->configDir . '/bin';
-            if (!is_dir($binDir) && !mkdir($binDir, 0700, true)) {
-                $this->output('  Failed to create directory: ' . $binDir, 'error');
-            }
-            elseif (!rename($pharPath, $binDir . '/' . $this->executable)) {
-                $this->output('  Failed to move the Phar to: ' . $binDir . '/' . $this->executable, 'error');
-            }
-            else {
-                $pharPath = $binDir . '/' . $this->executable;
-                $this->output('  Successfully moved the Phar to: ' . $pharPath);
-            }
-        }
-
-        $this->output(PHP_EOL . '  Running self:install command...' . PHP_EOL);
-        putenv('CLICOLOR_FORCE=' . ($this->terminalSupportsAnsi() ? '1' : '0'));
-        $result = $this->runCommand('php ' . $pharPath . ' self:install --yes');
-
-        exit($result);
+        return $result->getData();
     }
 
     /**
@@ -300,13 +349,13 @@ class Installer {
      */
     private function check($success, $failure, $condition, $exit = true) {
         if ($condition()) {
-            $this->output('  ✓ ' . $success, 'success');
+            $this->output('  [*] ' . $success, 'success');
         }
         elseif (!$exit) {
-            $this->output('  ! ' . $failure, 'warning');
+            $this->output('  [!] ' . $failure, 'warning');
         }
         else {
-            $this->output('  ✗ ' . $failure, 'error');
+            $this->output('  [X] ' . $failure, 'error');
             exit(1);
         }
     }
@@ -427,6 +476,38 @@ class Installer {
         }
 
         return false;
+    }
+}
+
+class TaskResult {
+    private $success = false;
+    private $message = '';
+    private $data;
+
+    private function __construct($success, $message = '', $data = null) {
+        $this->success = $success;
+        $this->message = $message;
+        $this->data = $data;
+    }
+
+    public static function success($data = null) {
+        return new self(true, '', $data);
+    }
+
+    public static function failure($errorMessage) {
+        return new self(false, $errorMessage);
+    }
+
+    public function isSuccess() {
+        return $this->success;
+    }
+
+    public function getMessage() {
+        return $this->message;
+    }
+
+    public function getData() {
+        return $this->data;
     }
 }
 

--- a/dist/installer.php
+++ b/dist/installer.php
@@ -184,7 +184,12 @@ class Installer {
         });
 
         $this->performTask('Downloading version ' . $latest['version'], function () use ($latest) {
-            if (!file_put_contents($this->pharName, file_get_contents($latest['url']))) {
+            $url = $latest['url'];
+            if (strpos($url, '//') === false) {
+                $removePath = parse_url($this->manifestUrl, PHP_URL_PATH);
+                $url = str_replace($removePath, '/' . ltrim($url, '/'), $this->manifestUrl);
+            }
+            if (!file_put_contents($this->pharName, file_get_contents($url))) {
                 return TaskResult::failure('The download failed');
             }
 
@@ -530,7 +535,7 @@ class VersionResolver {
             }
             if ($dashPos = strpos($version['version'], '-')) {
                 $suffix = substr($version['version'], $dashPos + 1);
-                if (!in_array($suffix, $allowedSuffixes)) {
+                if (!in_array($suffix, $allowedSuffixes) && !in_array('dev', $allowedSuffixes)) {
                     continue;
                 }
             }
@@ -559,7 +564,7 @@ class VersionResolver {
             }
             if ($dashPos = strpos($version['version'], '-')) {
                 $suffix = substr($version['version'], $dashPos + 1);
-                if (!in_array($suffix, $allowedSuffixes)) {
+                if (!in_array($suffix, $allowedSuffixes) && !in_array('dev', $allowedSuffixes)) {
                     $reasons[] = sprintf('Version %s has the suffix -%s, not allowed', $name, $suffix);
                     continue;
                 }

--- a/dist/installer.php
+++ b/dist/installer.php
@@ -105,17 +105,18 @@ class Installer {
         );
 
         $required_extensions = [
+            'curl',
             'openssl',
             'pcre',
         ];
         foreach ($required_extensions as $extension) {
             $this->check(
                 'The "' . $extension . '" PHP extension is installed.',
-                'Warning: the "' . $extension . '" PHP extension will be needed.',
+                'The "' . $extension . '" PHP extension is required.',
                 function () use ($extension) {
                     return extension_loaded($extension);
                 },
-                false
+                true
             );
         }
 
@@ -299,14 +300,14 @@ class Installer {
      */
     private function check($success, $failure, $condition, $exit = true) {
         if ($condition()) {
-            $this->output('  [*] ' . $success, 'success');
+            $this->output('  ✓ ' . $success, 'success');
+        }
+        elseif (!$exit) {
+            $this->output('  ! ' . $failure, 'warning');
         }
         else {
-            $this->output('  [ ] ' . $failure, $exit ? 'error' : 'warning');
-
-            if ($exit) {
-                exit(1);
-            }
+            $this->output('  ✗ ' . $failure, 'error');
+            exit(1);
         }
     }
 

--- a/src/Command/Self/SelfInstallCommand.php
+++ b/src/Command/Self/SelfInstallCommand.php
@@ -51,7 +51,7 @@ EOT
             // We can't do anything without these files, so exit.
             return 1;
         }
-        $this->stdErr->writeln(' done');
+        $this->stdErr->writeln(' <info>done</info>');
         $this->stdErr->writeln('');
 
         $this->stdErr->write('Setting up autocompletion...');
@@ -67,20 +67,20 @@ EOT
             $exitCode = $this->runOtherCommand('_completion', $args, $buffer);
             if ($exitCode === 0 && ($autoCompleteHook = $buffer->fetch())) {
                 $fs->dumpFile($configDir . '/autocompletion.sh', $autoCompleteHook);
-                $this->stdErr->writeln(' done');
+                $this->stdErr->writeln(' <info>done</info>');
             }
         } catch (\Exception $e) {
             // If stdout is not a terminal, then we tried but
             // autocompletion probably isn't needed at all, as we are in the
             // context of some kind of automated build. So ignore the error.
             if (!$this->isTerminal(STDOUT)) {
-                $this->stdErr->writeln(' skipped');
+                $this->stdErr->writeln(' <info>skipped</info>');
             }
             // Otherwise, print the error and continue. The user probably
             // wants to know what went wrong, but autocompletion is still not
             // essential.
             else {
-                $this->stdErr->writeln(' failed');
+                $this->stdErr->writeln(' <comment>failed</comment>');
                 $this->stdErr->writeln($this->indentAndWrap($e->getMessage()));
             }
         }
@@ -222,7 +222,7 @@ EOT
         }
 
         if (!file_put_contents($shellConfigFile, $newShellConfig)) {
-            $this->stdErr->writeln(sprintf('Failed to write to configuration file: %s', $shellConfigFile));
+            $this->stdErr->writeln(sprintf('Failed to write to configuration file: <error>%s</error>', $shellConfigFile));
             return 1;
         }
 


### PR DESCRIPTION
The CLI won't work at all without the pcre or openssl extensions, so making this check required won't break BC.

Without the curl extension, most requests will still work, but it's more maintainable just to require it. Manual installation can still bypass this check.