### PR TITLE
Add --branch option to push command

### DIFF
--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -5,6 +5,8 @@ use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Exception\RootNotFoundException;
 use Platformsh\Cli\Service\Ssh;
 use Platformsh\Client\Exception\EnvironmentStateException;
+use Platformsh\Client\Model\Environment;
+use Platformsh\Client\Model\Project;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -24,8 +26,9 @@ class EnvironmentPushCommand extends CommandBase
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Allow non-fast-forward updates')
             ->addOption('force-with-lease', null, InputOption::VALUE_NONE, 'Allow non-fast-forward updates, if the remote-tracking branch is up to date')
             ->addOption('set-upstream', 'u', InputOption::VALUE_NONE, 'Set the target environment as the upstream for the source branch')
+            ->addOption('branch', null, InputOption::VALUE_NONE, 'Create the environment as a branch')
             ->addOption('activate', null, InputOption::VALUE_NONE, 'Activate the environment after pushing')
-            ->addOption('parent', null, InputOption::VALUE_REQUIRED, 'Set a new environment parent (only used with --activate)');
+            ->addOption('parent', null, InputOption::VALUE_REQUIRED, 'Set a new environment parent (only used with --activate or --branch)');
         $this->addWaitOptions();
         $this->addProjectOption()
             ->addEnvironmentOption();
@@ -100,10 +103,20 @@ class EnvironmentPushCommand extends CommandBase
         ));
 
         $activate = false;
+        $createAsBranch = false;
         $parentId = null;
         if ($target !== 'master') {
+            // Determine whether to create the environment as a branch.
+            if (!$targetEnvironment) {
+                $createAsBranch = $input->getOption('branch')
+                    || ($input->isInteractive() && $questionHelper->confirm(sprintf(
+                        'Create <info>%s</info> as an active branch?',
+                        $target
+                    )));
+            }
+
             // Determine whether to activate the environment after pushing.
-            if (!$targetEnvironment || $targetEnvironment->status === 'inactive') {
+            if ($targetEnvironment && $targetEnvironment->status === 'inactive') {
                 $activate = $input->getOption('activate')
                     || ($input->isInteractive() && $questionHelper->confirm(sprintf(
                         'Activate <info>%s</info> after pushing?',
@@ -112,14 +125,37 @@ class EnvironmentPushCommand extends CommandBase
             }
 
             // If activating, determine what the environment's parent should be.
-            if ($activate) {
-                $parentId = $input->getOption('parent');
-                if (!$parentId) {
-                    $autoCompleterValues = array_keys($this->api()->getEnvironments($project));
-                    $parentId = $autoCompleterValues === ['master']
-                        ? 'master'
-                        : $questionHelper->askInput('Parent environment', 'master', $autoCompleterValues);
+            if ($activate || $createAsBranch) {
+                $parentId = $input->getOption('parent') ?: $this->findTargetParent($project, $targetEnvironment);
+            }
+
+            if ($createAsBranch) {
+                $parentEnvironment = $this->api()->getEnvironment($parentId, $project);
+                if (!$parentEnvironment) {
+                    throw new \RuntimeException("Parent environment not found: $parentId");
                 }
+                if (!$parentEnvironment->operationAvailable('branch', true)) {
+                    $this->stdErr->writeln(sprintf(
+                        'Operation not available: the environment %s cannot be branched.',
+                        $this->api()->getEnvironmentLabel($parentEnvironment, 'error')
+                    ));
+
+                    if ($parentEnvironment->is_dirty) {
+                        $this->stdErr->writeln('An activity is currently pending or in progress on the environment.');
+                    } elseif (!$parentEnvironment->isActive()) {
+                        $this->stdErr->writeln('The environment is not active.');
+                    }
+
+                    return 1;
+                }
+
+                $activity = $parentEnvironment->branch($target, $target);
+                $this->stdErr->writeln(sprintf(
+                    'Branched <info>%s</info> from parent %s',
+                    $target,
+                    $this->api()->getEnvironmentLabel($parentEnvironment)
+                ));
+                $this->debug(sprintf('Branch activity ID / state: %s / %s', $activity->id, $activity->state));
             }
         }
 
@@ -183,5 +219,30 @@ class EnvironmentPushCommand extends CommandBase
         }
 
         return 0;
+    }
+
+    /**
+     * Determines the parent of the target environment (for activate / branch).
+     *
+     * @param Project          $project
+     * @param Environment|null $targetEnvironment
+     *
+     * @return string The parent environment ID.
+     */
+    private function findTargetParent(Project $project, Environment $targetEnvironment = null) {
+        $environments = $this->api()->getEnvironments($project);
+        if ($targetEnvironment && $targetEnvironment->parent) {
+            $defaultId = $targetEnvironment->parent;
+        } elseif ($this->hasSelectedEnvironment()) {
+            $defaultId = $this->getSelectedEnvironment()->id;
+        } else {
+            $defaultId = $this->api()->getDefaultEnvironmentId($environments);
+        }
+        if (array_keys($environments) === [$defaultId]) {
+            return $defaultId;
+        }
+        $questionHelper = $this->getService('question_helper');
+
+        return $questionHelper->askInput('Parent environment', $defaultId, array_keys($environments));
     }
 }


### PR DESCRIPTION
Allows a new environment to be created as an active branch from a specified
parent - thus inheriting settings from that parent - rather than setting the
parent later.