### PR TITLE
WIP: Overriding the ConsoleForm form class resolveOptions method

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -80,6 +80,10 @@ service:
     - standard
     - medium
     - large
+  catalog:
+    - https://github.com/platformsh/template-builder/blob/master/templates/akeneo/.platform.template.yaml
+    - https://github.com/platformsh/template-builder/blob/master/templates/beego/.platform.template.yaml
+    - https://github.com/platformsh/template-builder/blob/master/templates/django1/.platform.template.yaml
 
 # Configuration relating to API calls.
 # This can be overridden in the user config file.

--- a/src/Command/Project/CreateConsoleForm.php
+++ b/src/Command/Project/CreateConsoleForm.php
@@ -18,19 +18,26 @@ class CreateConsoleForm extends Form
     {
         $values = [];
         $stdErr = $output instanceof ConsoleOutput ? $output->getErrorOutput() : $output;
+        print_r('catalog: ' . $input->getOption('catalog'));
+        print_r('template: ' . $input->getOption('template'));
         foreach ($this->fields as $key => $field) {
             $field->onChange($values);
 
-            //Check for the catalog flag.
+            // Check for the catalog flag.
             if ($field->getOptionName() == 'catalog_url' && $input->getOption('catalog')!==true) {
                 continue;
             }
-            //Check if the field should be initialized.
-            if ($field->getOptionName() == 'initialize' && 
-                ($input->getOption('catalog')!==true || $input->getOption('template')!==true)) {
-                continue;
+            // Check if the initialize field should be shown.
+            if ($field->getOptionName() == 'initialized') {
+                // Do not show if the neither catalog or template flags are present.
+                if ($input->getOption('catalog')==false && $input->getOption('template')==false) {
+                    continue;
+                }
+                // Do not show is the initialize flag is present.
+                if ($input->getOption('initialize')==true) {
+                    continue;
+                }
             }
-
             if (!$this->includeField($field, $values)) {
                 continue;
             }

--- a/src/Command/Project/CreateConsoleForm.php
+++ b/src/Command/Project/CreateConsoleForm.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Platformsh\Cli\Command\Project;
+
+use Platformsh\ConsoleForm\Form;
+use Platformsh\ConsoleForm\Exception\MissingValueException;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateConsoleForm extends Form
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveOptions(InputInterface $input, OutputInterface $output, QuestionHelper $helper)
+    {
+        $values = [];
+        $stdErr = $output instanceof ConsoleOutput ? $output->getErrorOutput() : $output;
+        foreach ($this->fields as $key => $field) {
+            $field->onChange($values);
+
+            //Check for the catalog flag.
+            if ($field->getOptionName() == 'catalog_url' && $input->getOption('catalog')!==true) {
+                continue;
+            }
+            //Check if the field should be initialized.
+            if ($field->getOptionName() == 'initialize' && 
+                ($input->getOption('catalog')!==true || $input->getOption('template')!==true)) {
+                continue;
+            }
+
+            if (!$this->includeField($field, $values)) {
+                continue;
+            }
+
+            // Get the value from the command-line options.
+            $value = $field->getValueFromInput($input, false);
+            if ($value !== null) {
+                $field->validate($value);
+            } elseif ($input->isInteractive()) {
+                // Get the value interactively.
+                $value = $helper->ask($input, $stdErr, $field->getAsQuestion());
+                $stdErr->writeln('');
+            } elseif ($field->isRequired()) {
+                throw new MissingValueException('--' . $field->getOptionName() . ' is required');
+            }
+
+            self::setNestedArrayValue(
+                $values,
+                $field->getValueKeys() ?: [$key],
+                $field->getFinalValue($value),
+                true
+            );
+        }
+
+        return $values;
+    }
+}

--- a/src/Command/Project/ProjectCreateCommand.php
+++ b/src/Command/Project/ProjectCreateCommand.php
@@ -8,8 +8,7 @@ use Platformsh\Cli\Console\Bot;
 use Platformsh\ConsoleForm\Field\Field;
 use Platformsh\ConsoleForm\Field\OptionsField;
 use Platformsh\ConsoleForm\Field\BooleanField;
-use Platformsh\ConsoleForm\Field\UrlField;
-use Platformsh\ConsoleForm\Form;
+use Platformsh\Cli\Command\Project\CreateConsoleForm;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,12 +28,15 @@ class ProjectCreateCommand extends CommandBase
           ->setAliases(['create'])
           ->setDescription('Create a new project');
 
-        $this->form = Form::fromArray($this->getFields());
+        $this->form = CreateConsoleForm::fromArray($this->getFields());
         $this->form->configureInputDefinition($this->getDefinition());
 
         $this->addOption('check-timeout', null, InputOption::VALUE_REQUIRED, 'The API timeout while checking the project status', 30)
             ->addOption('timeout', null, InputOption::VALUE_REQUIRED, 'The total timeout for all API checks (0 to disable the timeout)', 900)
-            ->addOption('template', null, InputOption::VALUE_OPTIONAL, 'Choose a starting template or provide a url of one.', false);
+            ->addOption('template', null, InputOption::VALUE_REQUIRED, 'Choose a starting template or provide a url of one.')
+            ->addOption('catalog', null, InputOption::VALUE_NONE, 'Choose a template from the catalog')            
+            ->addOption('initialize', null, InputOption::VALUE_NONE, 'Initialize the project after it has been created.');
+
 
         $this->setHelp(<<<EOF
 Use this command to create a new project.
@@ -63,20 +65,6 @@ EOF
 
         $options = $this->form->resolveOptions($input, $output, $questionHelper);
 
-        if ($input->getOption('template') !== false) {
-            if (empty(parse_url($input->getOption('template'), PHP_URL_PATH))) {
-                $temp_provided = true;
-            }
-            else {
-                $temp_provided = false;
-            }
-            $this->template_form = Form::fromArray($this->getTemplateFields($temp_provided));
-            $this->template_form->configureInputDefinition($this->getDefinition());
-            $template_options = $this->template_form->resolveOptions($input, $output, $questionHelper);
-    
-        }
-
-
         $estimate = $this->api()
             ->getClient()
             ->getSubscriptionEstimate($options['plan'], $options['storage'], $options['environments'], 1);
@@ -95,15 +83,14 @@ EOF
         if (!$questionHelper->confirm($costConfirm)) {
             return 1;
         }
-
-        // Grab the url of the yaml file.
-        if (!empty($template_options['catalog_url'])) {
-            $options['catalog'] = $template_options['catalog_url'];
+        if (!empty($options['catalog_url'])) {
+            $options['catalog'] = $options['catalog_url'];
         }
-        else if (!empty($template_options['catalog_url'])) {
-            $options['catalog'] = $template_options['template_url'];
+        else if (!empty($input->getOption('template'))) {
+            $options['catalog'] = $input->getOption('template');
         }
         
+
         $subscription = $this->api()->getClient()
             ->createSubscription(
                 $options['catalog'],
@@ -172,7 +159,7 @@ EOF
             return 1;
         }
 
-        if ($template_options['initialize']) {
+        if ($options['initialize']) {
             // Use the existing initialize command.
             $project = $this->selectProject($subscription->project_id);
             $environment = $this->api()->getEnvironment('master', $project, null, true);
@@ -300,41 +287,15 @@ EOF
             'questionLine' => '',
             'default' => 'Untitled Project',
           ]);
-
-        //   $fields['template_option'] = new OptionsField('Template Options', [
-        //     'optionName' => 'template_option',
-        //     'options' => [
-        //         'Provide your own template url.',
-        //         'Choose a template from the catalog.',
-        //         'No template at this time.',
-        //     ],
-        //     'description' => 'Choose a template, provide a url or choose not to use one.',
-        //     'includeAsOption' => false,
-        //     ]);
-        //   $fields['catalog_url'] = new OptionsField('Catalog', [
-        //     'optionName' => 'catalog_url',
-        //     'conditions' => [
-        //         'template_option' => [
-        //             'Choose a template from the catalog.'
-        //         ],
-        //     ],
-        //     'description' => 'The template from which to create your project or your own blank project.',
-        //     'options' => $this->getAvailableCatalog(),
-        //     'asChoice' => FALSE,
-        //     'optionsCallback' => function () {
-        //         return $this->getAvailableCatalog(true);
-        //         },
-        //     ]);
-        //   $fields['template_url'] = new UrlField('Template URL', [
-        //     'optionName' => 'template_url',
-        //     'conditions' => [
-        //         'template_option' => [
-        //             'Provide your own template url.'
-        //         ],
-        //     ],
-        //     'description' => 'The template url',
-        //     'questionLine' => 'What is the URL of the template?',
-        //   ]);  
+          $fields['catalog_url'] = new OptionsField('Catalog', [
+            'optionName' => 'catalog_url',
+            'description' => 'The template from which to create your project or your own blank project.',
+            'options' => $this->getAvailableCatalog(),
+            'asChoice' => FALSE,
+            'optionsCallback' => function () {
+                return $this->getAvailableCatalog(true);
+                },
+            ]);
           $fields['region'] = new OptionsField('Region', [
             'optionName' => 'region',
             'description' => 'The region where the project will be hosted',
@@ -368,80 +329,11 @@ EOF
                 return is_numeric($value) && $value > 0 && $value < 1024;
             },
           ]);
-        //   $fields['initialize'] = new BooleanField('Initialize', [
-        //     'optionName' => 'initialized',
-        //     'conditions' => [
-        //         'template_option' => [
-        //             'Provide your own template url.',
-        //             'Choose a template from the catalog.',
-        //         ],
-        //     ],
-        //     'description' => 'Initialize this environment?',
-        //     'questionLine' => 'Initialize this environment?',
-        //   ]);
-
-        return $fields;
-    }
-
-     /**
-     * Returns a list of ConsoleForm form fields for this command.
-     *
-     * @return Field[]
-     */
-    protected function getTemplateFields($url_provided)
-    {
-        $fields = [];
-        
-        if (!$url_provided) {
-            $fields['template_option'] = new OptionsField('Template Options', [
-                'optionName' => 'template_option',
-                'options' => [
-                    'Provide your own template url.',
-                    'Choose a template from the catalog.',
-                    'No template at this time.',
-                ],
-                'description' => 'Choose a template, provide a url or choose not to use one.',
-                'includeAsOption' => false,
-            ]);
-    
-            $fields['catalog_url'] = new OptionsField('Catalog', [
-            'optionName' => 'catalog_url',
-            'conditions' => [
-                'template_option' => [
-                    'Choose a template from the catalog.'
-                ],
-            ],
-            'description' => 'The template from which to create your project or your own blank project.',
-            'options' => $this->getAvailableCatalog(),
-            'asChoice' => FALSE,
-            'optionsCallback' => function () {
-                return $this->getAvailableCatalog(true);
-                },
-            ]);
-
-            $fields['template_url'] = new UrlField('Template URL', [
-            'optionName' => 'template_url',
-            'conditions' => [
-                'template_option' => [
-                    'Provide your own template url.'
-                ],
-            ],
-            'description' => 'The template url',
-            'questionLine' => 'What is the URL of the template?',
-            ]);  
-        }
-        
-        $fields['initialize'] = new BooleanField('Initialize', [
-        'optionName' => 'initialized',
-        'conditions' => [
-            'template_option' => [
-                'Provide your own template url.',
-                'Choose a template from the catalog.',
-            ],
-        ],
-        'description' => 'Initialize this environment?',
-        'questionLine' => 'Initialize this environment?',
-        ]);
+          $fields['initialize'] = new BooleanField('Initialize', [
+            'optionName' => 'initialized',
+            'description' => 'Initialize this environment?',
+            'questionLine' => 'Initialize this environment?',
+          ]);
 
         return $fields;
     }

--- a/src/Command/Project/ProjectCreateCommand.php
+++ b/src/Command/Project/ProjectCreateCommand.php
@@ -60,6 +60,15 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($input->getOption('initialize')==true && 
+            ($input->getOption('catalog')==false && 
+            $input->getOption('template')==false)) {
+
+            $this->stdErr->writeln("Projects cannot be initialized without a template file. 
+If you would like to use the --initialize option please provide a template file by utilizing 
+the --template or --catalog options. For more information on this command please type project:create --help.");
+            return 0;
+        }
         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
         $questionHelper = $this->getService('question_helper');
 
@@ -160,6 +169,10 @@ EOF
         }
 
         if ($options['initialize']) {
+            // Check that the profile and repository are present and initializable.
+            if (empty($subscription->project_options['initialize']['repository'])) {
+                $this->stdErr->writeln("The project has been created but cannot be initialized because the project repository is empty.");
+            }
             // Use the existing initialize command.
             $project = $this->selectProject($subscription->project_id);
             $environment = $this->api()->getEnvironment('master', $project, null, true);


### PR DESCRIPTION
`project:create` will now take three different flags: 

- `--template` (requires a url to be passed)
- `--catalog` (will add a field to the interactive form)
- `--initialize` (will initialize the project after it's been created, this needs a few tweaks)