### PR TITLE
Use primary route URL from deployments API in Drush aliases

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -42,7 +42,7 @@ services:
 
     drush:
         class:     '\Platformsh\Cli\Service\Drush'
-        arguments: ['@config', '@shell', '@local.project']
+        arguments: ['@config', '@shell', '@local.project', '@api']
 
     fs:
         class:     '\Platformsh\Cli\Service\Filesystem'

--- a/src/Service/Drush.php
+++ b/src/Service/Drush.php
@@ -15,6 +15,9 @@ use Platformsh\Client\Model\Project;
 
 class Drush
 {
+    /** @var Api */
+    protected $api;
+
     /** @var Shell */
     protected $shellHelper;
 
@@ -40,18 +43,21 @@ class Drush
     protected $cachedAppRoots = [];
 
     /**
-     * @param Config|null       $config
-     * @param Shell|null        $shellHelper
+     * @param Config|null $config
+     * @param Shell|null $shellHelper
      * @param LocalProject|null $localProject
+     * @param Api|null $api
      */
     public function __construct(
         Config $config = null,
         Shell $shellHelper = null,
-        LocalProject $localProject = null
+        LocalProject $localProject = null,
+        Api $api = null
     ) {
         $this->shellHelper = $shellHelper ?: new Shell();
         $this->config = $config ?: new Config();
         $this->localProject = $localProject ?: new LocalProject();
+        $this->api = $api ?: new Api($this->config);
     }
 
     public function setHomeDir($homeDir)
@@ -353,6 +359,21 @@ class Drush
         $types[] = new DrushPhp($this->config, $this);
 
         return $types;
+    }
+
+    /**
+     * Returns the site URL.
+     *
+     * @param Environment      $environment
+     * @param LocalApplication $app
+     *
+     * @todo this is really a hidden dependency on the Api service
+     *
+     * @return string|null
+     */
+    public function getSiteUrl(Environment $environment, LocalApplication $app)
+    {
+        return $this->api->getSiteUrl($environment, $app->getName());
     }
 
     /**

--- a/src/SiteAlias/DrushAlias.php
+++ b/src/SiteAlias/DrushAlias.php
@@ -261,39 +261,11 @@ abstract class DrushAlias implements SiteAliasTypeInterface
 
         list($alias['user'], $alias['host']) = explode('@', $sshUrl, 2);
 
-        if ($url = $this->getUrl($environment)) {
+        if ($url = $this->drush->getSiteUrl($environment, $app)) {
             $alias['uri'] = $url;
         }
 
         return $alias;
-    }
-
-    /**
-     * Find a single URL for an environment.
-     *
-     * Only one URL may be used for the Drush site alias. This picks the
-     * shortest one available, strongly preferring HTTPS.
-     *
-     * @param \Platformsh\Client\Model\Environment $environment
-     *
-     * @return string|false A URL, or false if no URLs are found.
-     */
-    private function getUrl(Environment $environment)
-    {
-        $urls = $environment->getRouteUrls();
-        usort($urls, function ($a, $b) {
-            $result = 0;
-            foreach ([$a, $b] as $key => $url) {
-                if (parse_url($url, PHP_URL_SCHEME) === 'https') {
-                    $result += $key === 0 ? -2 : 2;
-                }
-            }
-            $result += strlen($a) <= strlen($b) ? -1 : 1;
-
-            return $result;
-        });
-
-        return reset($urls);
     }
 
     /**

--- a/tests/Service/DrushServiceMock.php
+++ b/tests/Service/DrushServiceMock.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Platformsh\Cli\Tests\Service;
+
+use Platformsh\Cli\Local\LocalApplication;
+use Platformsh\Cli\Service\Config;
+use Platformsh\Cli\Service\Drush;
+use Platformsh\Client\Model\Environment;
+
+class DrushServiceMock extends Drush
+{
+    public function __construct()
+    {
+        $config = new Config();
+        $config->override('service.app_config_file', '_platform.app.yaml');
+
+        parent::__construct($config);
+    }
+
+    /**
+     * @param Environment $environment
+     * @param LocalApplication $app
+     *
+     * @return string|null
+     */
+    public function getSiteUrl(Environment $environment, LocalApplication $app)
+    {
+        return $environment->getPublicUrl();
+    }
+}

--- a/tests/Service/DrushServiceTest.php
+++ b/tests/Service/DrushServiceTest.php
@@ -4,6 +4,7 @@ namespace Platformsh\Cli\Tests;
 
 use Platformsh\Cli\Service\Drush;
 use Platformsh\Cli\Service\Filesystem;
+use Platformsh\Cli\Tests\Service\DrushServiceMock;
 use Platformsh\Client\Model\Environment;
 use Platformsh\Client\Model\Project;
 use Symfony\Component\Yaml\Yaml;
@@ -29,7 +30,7 @@ class DrushServiceTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->drush = new Drush();
+        $this->drush = new DrushServiceMock();
 
         // Set up a dummy project with a remote environment.
         $this->project = new Project([


### PR DESCRIPTION
Now Drush aliases have the same URL that is used in the 'platform drush'
command. The deployment routes are filtered to only the 'upstream' routes that
match the app, then one is selected, preferring the primary route, and then
preferring HTTPS routes, and then preferring short URLs. If no route is found
the fallback is the environment's 'public-url' HAL link.

There could be a performance hit for new or updated environments as the
deployment resource will be fetched as well as the environment. But the API is
quite quick when a connection is already open, and deployments are cached
against the environment HEAD commit.

(the ugly part is that this introduces is another dependency on the Api service)