### PR TITLE
Added support for scp

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -113,6 +113,10 @@ services:
         class:     '\Platformsh\Cli\Service\Ssh'
         arguments: ['@input', '@output']
 
+    scp:
+        class:     '\Platformsh\Cli\Service\Scp'
+        arguments: ['@input', '@output']
+
     state:
         class:     '\Platformsh\Cli\Service\State'
         arguments: ['@config']

--- a/src/Application.php
+++ b/src/Application.php
@@ -133,6 +133,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Environment\EnvironmentRedeployCommand();
         $commands[] = new Command\Environment\EnvironmentRelationshipsCommand();
         $commands[] = new Command\Environment\EnvironmentSshCommand();
+        $commands[] = new Command\Environment\EnvironmentScpCommand();
         $commands[] = new Command\Environment\EnvironmentSynchronizeCommand();
         $commands[] = new Command\Environment\EnvironmentUrlCommand();
         $commands[] = new Command\Environment\EnvironmentSetRemoteCommand();

--- a/src/Command/Environment/EnvironmentScpCommand.php
+++ b/src/Command/Environment/EnvironmentScpCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Platformsh\Cli\Command\Environment;
+
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Service\Ssh;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnvironmentScpCommand extends CommandBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('environment:scp')
+            ->setAliases(['scp'])
+            ->addArgument('files', InputArgument::IS_ARRAY, 'Files to copy. Use the remote: prefix to define remote locations.')
+            ->addOption('recursive', 'r', InputOption::VALUE_NONE, 'Recursively copy entire directories..')
+            ->setDescription('Copy files to and from current environment using scp');
+        $this->addProjectOption()
+            ->addEnvironmentOption()
+            ->addRemoteContainerOptions();
+        Ssh::configureInput($this->getDefinition());
+        $this->addExample('Copy local files a.txt and b.txt to remote mount var/files', "a.txt b.txt remote:var/files");
+        $this->addExample('Copy remote files c.txt to current directory', "remote:c.txt .");
+        $this->addExample('Copy subdirectory dump/ to remote mount var/files', "-r dump remote:var/logs");
+        $this->addExample('Copy files inside subdirectory dump/ to remote mount var/files', "-r dump/* remote:var/logs");
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $files = $input->getArgument('files');
+        if (!$files) {
+            throw new InvalidArgumentException('No files specified');
+        }
+
+        $this->validateInput($input);
+        $environment = $this->getSelectedEnvironment();
+
+        $container = $this->selectRemoteContainer($input);
+        $sshUrl = $container->getSshUrl();
+
+        /** @var \Platformsh\Cli\Service\Scp $scp */
+        $scp = $this->getService('scp');
+        $scpOptions = [];
+        $command = $scp->getScpCommand($scpOptions);
+
+        if ($input->getOption('recursive')) {
+            $command .= ' -r';
+        }
+
+        if ($input->getOption('quiet')) {
+            $command .= ' -q';
+        }
+
+        $remoteUsed = false;
+        foreach ($files as $key => $file) {
+            if (strncasecmp($file, 'remote:', '7') === 0) {
+                $command .= ' ' . $sshUrl . ':' . escapeshellarg(substr($file, 7));
+                $remoteUsed = true;
+            } else {
+                $command .= ' ' . escapeshellarg($file);
+            }
+        }
+
+        if (!$remoteUsed) {
+            throw new InvalidArgumentException('At lest one argument needs to contain the "remote:" prefix');
+        }
+
+        /** @var \Platformsh\Cli\Service\Shell $shell */
+        $shell = $this->getService('shell');
+
+        return $shell->executeSimple($command);
+    }
+}

--- a/src/Command/Environment/EnvironmentScpCommand.php
+++ b/src/Command/Environment/EnvironmentScpCommand.php
@@ -21,7 +21,7 @@ class EnvironmentScpCommand extends CommandBase
             ->setName('environment:scp')
             ->setAliases(['scp'])
             ->addArgument('files', InputArgument::IS_ARRAY, 'Files to copy. Use the remote: prefix to define remote locations.')
-            ->addOption('recursive', 'r', InputOption::VALUE_NONE, 'Recursively copy entire directories..')
+            ->addOption('recursive', 'r', InputOption::VALUE_NONE, 'Recursively copy entire directories')
             ->setDescription('Copy files to and from current environment using scp');
         $this->addProjectOption()
             ->addEnvironmentOption()

--- a/src/Command/Environment/EnvironmentScpCommand.php
+++ b/src/Command/Environment/EnvironmentScpCommand.php
@@ -72,7 +72,7 @@ class EnvironmentScpCommand extends CommandBase
         }
 
         if (!$remoteUsed) {
-            throw new InvalidArgumentException('At lest one argument needs to contain the "remote:" prefix');
+            throw new InvalidArgumentException('At least one argument needs to contain the "remote:" prefix');
         }
 
         /** @var \Platformsh\Cli\Service\Shell $shell */

--- a/src/Command/Environment/EnvironmentScpCommand.php
+++ b/src/Command/Environment/EnvironmentScpCommand.php
@@ -61,7 +61,7 @@ class EnvironmentScpCommand extends CommandBase
 
         $remoteUsed = false;
         foreach ($files as $key => $file) {
-            if (strncasecmp($file, 'remote:', '7') === 0) {
+            if (strpos($file, 'remote:') === 0) {
                 $command .= ' ' . $sshUrl . ':' . escapeshellarg(substr($file, 7));
                 $remoteUsed = true;
             } else {

--- a/src/Command/Environment/EnvironmentScpCommand.php
+++ b/src/Command/Environment/EnvironmentScpCommand.php
@@ -62,7 +62,7 @@ class EnvironmentScpCommand extends CommandBase
         $remoteUsed = false;
         foreach ($files as $key => $file) {
             if (strpos($file, 'remote:') === 0) {
-                $command .= ' ' . $sshUrl . ':' . escapeshellarg(substr($file, 7));
+                $command .= ' ' . escapeshellarg($sshUrl . ':' . substr($file, 7));
                 $remoteUsed = true;
             } else {
                 $command .= ' ' . escapeshellarg($file);

--- a/src/Command/Environment/EnvironmentScpCommand.php
+++ b/src/Command/Environment/EnvironmentScpCommand.php
@@ -55,7 +55,9 @@ class EnvironmentScpCommand extends CommandBase
             $command .= ' -r';
         }
 
-        if ($input->getOption('quiet')) {
+        if ($output->isVerbose()) {
+            $command .= ' -v';
+        } elseif ($output->isQuiet()) {
             $command .= ' -q';
         }
 

--- a/src/Service/Scp.php
+++ b/src/Service/Scp.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Platformsh\Cli\Service;
+
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Scp implements InputConfiguringInterface
+{
+    protected $input;
+    protected $output;
+
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+        $this->output = $output;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputDefinition $definition
+     */
+    public static function configureInput(InputDefinition $definition)
+    {
+        $definition->addOption(
+            new InputOption('identity-file', 'i', InputOption::VALUE_REQUIRED, 'An SSH identity (private key) to use')
+        );
+    }
+
+    /**
+     * @param array $extraOptions
+     *
+     * @return array
+     */
+    public function getScpArgs(array $extraOptions = [])
+    {
+        $options = array_merge($this->getScpOptions(), $extraOptions);
+
+        $args = [];
+        foreach ($options as $name => $value) {
+            $args[] = '-o';
+            $args[] = $name . ' ' . $value;
+        }
+
+        return $args;
+    }
+
+    /**
+     * Returns an array of SCP options, based on the input options.
+     *
+     * @return string[] An array of SCP options.
+     */
+    protected function getScpOptions()
+    {
+        $options = [];
+
+        if ($this->input->hasOption('identity-file') && $this->input->getOption('identity-file')) {
+            $file = $this->input->getOption('identity-file');
+            if (!file_exists($file)) {
+                throw new \InvalidArgumentException('Identity file not found: ' . $file);
+            }
+            $options['IdentitiesOnly'] = 'yes';
+            $options['IdentityFile'] = $file;
+        }
+
+        if ($this->output->isDebug()) {
+            $options['LogLevel'] = 'DEBUG';
+        } elseif ($this->output->isVeryVerbose()) {
+            $options['LogLevel'] = 'VERBOSE';
+        } elseif ($this->output->isQuiet()) {
+            $options['LogLevel'] = 'QUIET';
+        }
+
+        return $options;
+    }
+
+    /**
+     * Returns an SCP command line.
+     *
+     * @param array $extraOptions
+     *
+     * @return string
+     */
+    public function getScpCommand(array $extraOptions = [])
+    {
+        $command = 'scp';
+        $args = $this->getScpArgs($extraOptions);
+        if (!empty($args)) {
+            $command .= ' ' . implode(' ', array_map('escapeshellarg', $args));
+        }
+
+        return $command;
+    }
+}


### PR DESCRIPTION
So, you currently have support for `ssh` and `mount:upload` and `mount:download`, but I find it more convenient if we could use more or less the scp syntax. Besides, the `mount` commands works on directories, making it impossible to upload/download single files.

The whole point with the `scp` command is to avoid  having to fetch the ssh url all the time, ie:

```
scp a.txt foobar2123123-master-7rqtwti--app@ssh.eu-2.platform.sh:var/upload
```

Instead, it is a simple as:
```
#upload
platform scp a.txt remote:var/upload

#upload multiple files
platform scp a.txt b.txt c.txt remote:var/upload


#download
platform scp remote:var/upload/a.txt .

```

I am aware of the  workaround given below, but I think supporting scp directly is way better
```
scp "$(platform ssh --pipe)":var/upload/a.txt .
```