### PR TITLE
bugfixing some PE customers

### DIFF
--- a/src/Command/Db/DbSizeCommand.php
+++ b/src/Command/Db/DbSizeCommand.php
@@ -363,7 +363,7 @@ class DbSizeCommand extends CommandBase
             $this->debug('Checking InnoDB separately for more accurate results...');
             try {
                 $innoDbSize = $host->runCommand($this->mysqlInnodbQuery($database));
-            }catch(Throwable $e) {//some PE clusters do not have the  PROCESS privilege(s) and thus, have no access to the sys_tablespaces, revert to legacy way 
+            }catch(\Symfony\Component\Process\Exception\RuntimeException $e) {//some PE clusters do not have the  PROCESS privilege(s) and thus, have no access to the sys_tablespaces, revert to legacy way 
                 $allocatedSizeSupported = false;
             }
         }

--- a/src/Command/Db/DbSizeCommand.php
+++ b/src/Command/Db/DbSizeCommand.php
@@ -361,7 +361,11 @@ class DbSizeCommand extends CommandBase
         $innoDbSize = 0;
         if ($allocatedSizeSupported) {
             $this->debug('Checking InnoDB separately for more accurate results...');
-            $innoDbSize = $host->runCommand($this->mysqlInnodbQuery($database));
+            try {
+                $innoDbSize = $host->runCommand($this->mysqlInnodbQuery($database));
+            }catch(Throwable $e) {//some PE clusters do not have the  PROCESS privilege(s) and thus, have no access to the sys_tablespaces, revert to legacy way 
+                $allocatedSizeSupported = false;
+            }
         }
 
         $otherSizes = $host->runCommand($this->mysqlNonInnodbQuery($database, (bool) $allocatedSizeSupported));


### PR DESCRIPTION
some PE clusters do not have the  PROCESS privilege(s) and thus, have no access to the sys_tablespaces, revert to legacy way