### PR TITLE
Stop showing a redeploy warning when embedded activities aren't provided

### DIFF
--- a/src/Command/Environment/EnvironmentHttpAccessCommand.php
+++ b/src/Command/Environment/EnvironmentHttpAccessCommand.php
@@ -195,9 +195,7 @@ class EnvironmentHttpAccessCommand extends CommandBase
                 $output->writeln($formatter->format($selectedEnvironment->http_access, 'http_access'));
 
                 $success = true;
-                if (!$result->countActivities()) {
-                    $this->redeployWarning();
-                } elseif ($this->shouldWait($input)) {
+                if ($this->shouldWait($input)) {
                     /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
                     $activityMonitor = $this->getService('activity_monitor');
                     $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Environment/EnvironmentInfoCommand.php
+++ b/src/Command/Environment/EnvironmentInfoCommand.php
@@ -134,14 +134,11 @@ class EnvironmentInfoCommand extends CommandBase
 
         $this->api()->clearEnvironmentsCache($environment->project);
 
-        $rebuildProperties = ['enable_smtp', 'restrict_robots'];
         $success = true;
-        if ($result->countActivities() && !$noWait) {
+        if (!$noWait) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());
-        } elseif (!$result->countActivities() && in_array($property, $rebuildProperties)) {
-            $this->redeployWarning();
         }
 
         return $success ? 0 : 1;

--- a/src/Command/Project/Variable/ProjectVariableSetCommand.php
+++ b/src/Command/Project/Variable/ProjectVariableSetCommand.php
@@ -67,9 +67,7 @@ class ProjectVariableSetCommand extends CommandBase
         $this->stdErr->writeln("Variable <info>$variableName</info> set to: $variableValue");
 
         $success = true;
-        if (!$result->countActivities()) {
-            $this->redeployWarning();
-        } elseif ($this->shouldWait($input)) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Variable/VariableCreateCommand.php
+++ b/src/Command/Variable/VariableCreateCommand.php
@@ -155,7 +155,7 @@ class VariableCreateCommand extends VariableCommandBase
         $this->displayVariable($result->getEntity());
 
         $success = true;
-        if (!$result->countActivities()) {
+        if (!$result->countActivities() && $level !== 'environment') {
             $this->redeployWarning();
         } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */

--- a/src/Command/Variable/VariableDeleteCommand.php
+++ b/src/Command/Variable/VariableDeleteCommand.php
@@ -50,10 +50,12 @@ class VariableDeleteCommand extends VariableCommandBase
             return 1;
         }
 
+        $level = $this->getVariableLevel($variable);
+
         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
         $questionHelper = $this->getService('question_helper');
 
-        switch ($this->getVariableLevel($variable)) {
+        switch ($level) {
             case 'environment':
                 $environmentId = $this->getSelectedEnvironment()->id;
                 $confirm = $questionHelper->confirm(
@@ -81,7 +83,7 @@ class VariableDeleteCommand extends VariableCommandBase
         $this->stdErr->writeln("Deleted variable <info>$variableName</info>");
 
         $success = true;
-        if (!$result->countActivities()) {
+        if (!$result->countActivities() && $level !== 'environment') {
             $this->redeployWarning();
         } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */

--- a/src/Command/Variable/VariableSetCommand.php
+++ b/src/Command/Variable/VariableSetCommand.php
@@ -69,9 +69,7 @@ class VariableSetCommand extends CommandBase
         $this->stdErr->writeln("Variable <info>$variableName</info> set to: $variableValue");
 
         $success = true;
-        if (!$result->countActivities()) {
-            $this->redeployWarning();
-        } elseif ($this->shouldWait($input)) {
+        if ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());

--- a/src/Command/Variable/VariableUpdateCommand.php
+++ b/src/Command/Variable/VariableUpdateCommand.php
@@ -84,7 +84,7 @@ class VariableUpdateCommand extends VariableCommandBase
         $this->displayVariable($variable);
 
         $success = true;
-        if (!$result->countActivities()) {
+        if (!$result->countActivities() && $level !== 'environment') {
             $this->redeployWarning();
         } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */


### PR DESCRIPTION
Activities are no longer embedded in the response (the Result) for actions that
trigger activities. We therefore cannot use the absence of activities as
evidence that the environment has not been automatically redeployed.