### PR TITLE
Report real progress time in activity log

### DIFF
--- a/src/Command/Activity/ActivityLogCommand.php
+++ b/src/Command/Activity/ActivityLogCommand.php
@@ -5,11 +5,9 @@ use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Service\ActivityMonitor;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Client\Model\Activity;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ActivityLogCommand extends CommandBase
@@ -87,32 +85,9 @@ class ActivityLogCommand extends CommandBase
 
         $refresh = $input->getOption('refresh');
         if ($refresh > 0 && !$this->runningViaMulti && !$activity->isComplete()) {
-            $progressOutput = $this->stdErr->isDecorated() ? $this->stdErr : new NullOutput();
-            $bar = new ProgressBar($progressOutput);
-            $bar->setPlaceholderFormatterDefinition('state', function () use ($activity) {
-                return ActivityMonitor::formatState($activity->state);
-            });
-            $bar->setFormat('[%bar%] %elapsed:6s% (%state%)');
-            $bar->start();
-
-            $activity->wait(
-                function () use ($bar) {
-                    $bar->advance();
-                },
-                function ($log) use ($output, $bar, $progressOutput) {
-                    // Clear the progress bar and ensure the current line is flushed.
-                    $bar->clear();
-                    $progressOutput->write($progressOutput->isDecorated() ? "\n\033[1A" : "\n");
-
-                    // Display the new log output.
-                    $output->write($log);
-
-                    // Display the progress bar again.
-                    $bar->advance();
-                },
-                $refresh
-            );
-            $bar->clear();
+            /** @var ActivityMonitor $monitor */
+            $monitor = $this->getService('activity_monitor');
+            $monitor->waitAndLog($activity, null, null, $refresh, false);
 
             // Once the activity is complete, something has probably changed in
             // the project's environments, so this is a good opportunity to


### PR DESCRIPTION
This will base the start time on the activity's start or created date, rather
than when the CLI process started to wait.