### PR TITLE
Setup options plan region lists

### DIFF
--- a/src/Command/Project/ProjectCreateCommand.php
+++ b/src/Command/Project/ProjectCreateCommand.php
@@ -212,7 +212,7 @@ EOF
     {
         // Check for setup options.
         $account = $this->api()->getMyAccount(true);
-        print_r($account);
+        // print_r($account);
         $setupOptions = $this->api()->getClient()->getSetupOptions(NULL, NULL, NULL, $account['username'], NULL);
         if (isset($setupOptions) && !empty($setupOptions['regions'])) {
             $regions = $setupOptions['regions'];

--- a/src/Command/Project/ProjectCreateCommand.php
+++ b/src/Command/Project/ProjectCreateCommand.php
@@ -170,23 +170,31 @@ EOF
     protected function getAvailablePlans($runtime = false)
     {
         static $plans;
-        if (is_array($plans)) {
-            return $plans;
+        // Check for setup options.
+        $account = $this->api()->getMyAccount(true);
+        $setupOptions = $this->api()->getClient()->getSetupOptions(NULL, NULL, NULL, $account['username'], NULL);
+        if (isset($setupOptions) && !empty($setupOptions['plans'])) {
+            $plans = $setupOptions['plans'];
         }
-
-        if (!$runtime) {
-            return (array) $this->config()->get('service.available_plans');
-        }
-
-        $plans = [];
-        foreach ($this->api()->getClient()->getPlans() as $plan) {
-            if ($plan->hasProperty('price', false)) {
-                $plans[$plan->name] = sprintf('%s (%s)', $plan->label, $plan->price->__toString());
-            } else {
-                $plans[$plan->name] = $plan->label;
+        else {
+            if (is_array($plans)) {
+                return $plans;
             }
+    
+            if (!$runtime) {
+                return (array) $this->config()->get('service.available_plans');
+            }
+    
+            $plans = [];
+            foreach ($this->api()->getClient()->getPlans() as $plan) {
+                if ($plan->hasProperty('price', false)) {
+                    $plans[$plan->name] = sprintf('%s (%s)', $plan->label, $plan->price->__toString());
+                } else {
+                    $plans[$plan->name] = $plan->label;
+                }
+            }
+    
         }
-
         return $plans;
     }
 
@@ -202,17 +210,25 @@ EOF
      */
     protected function getAvailableRegions($runtime = false)
     {
-        if ($runtime) {
-            $regions = [];
-            foreach ($this->api()->getClient()->getRegions() as $region) {
-                if ($region->available) {
-                    $regions[$region->id] = $region->label;
-                }
-            }
-        } else {
-            $regions = (array) $this->config()->get('service.available_regions');
+        // Check for setup options.
+        $account = $this->api()->getMyAccount(true);
+        print_r($account);
+        $setupOptions = $this->api()->getClient()->getSetupOptions(NULL, NULL, NULL, $account['username'], NULL);
+        if (isset($setupOptions) && !empty($setupOptions['regions'])) {
+            $regions = $setupOptions['regions'];
         }
-
+        else {
+            if ($runtime) {
+                $regions = [];
+                foreach ($this->api()->getClient()->getRegions() as $region) {
+                    if ($region->available) {
+                        $regions[$region->id] = $region->label;
+                    }
+                }
+            } else {
+                $regions = (array) $this->config()->get('service.available_regions');
+            }
+        }
         return $regions;
     }
 


### PR DESCRIPTION
This branch updates the `create` project command to look to the `setup/options` api before falling back into the general plans/regions lists so that if a user has a `user_project_options` file specified it is respected. This is dependent on PR #831 and will need to be rebased once that branch is finalized. This branch is dependent on the cli updates found in PRs https://github.com/platformsh/platformsh-client-php/pull/37 and https://github.com/platformsh/platformsh-client-php/pull/39.