### PR TITLE
WIP: Add API token login command

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -26,7 +26,11 @@ services:
 
     api:
         class:     '\Platformsh\Cli\Service\Api'
-        arguments: ['@config', '@cache']
+        arguments: ['@config', '@cache', '@api_token_storage']
+
+    api_token_storage:
+      class:     '\Platformsh\Cli\Service\ApiTokenStorage'
+      arguments: ['@config']
 
     cache:
         class:     '\Doctrine\Common\Cache\CacheProvider'

--- a/src/Application.php
+++ b/src/Application.php
@@ -107,6 +107,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Auth\AuthInfoCommand();
         $commands[] = new Command\Auth\AuthTokenCommand();
         $commands[] = new Command\Auth\LogoutCommand();
+        $commands[] = new Command\Auth\ApiTokenLoginCommand();
         $commands[] = new Command\Auth\PasswordLoginCommand();
         $commands[] = new Command\Auth\BrowserLoginCommand();
         $commands[] = new Command\Certificate\CertificateAddCommand();

--- a/src/Command/Auth/ApiTokenLoginCommand.php
+++ b/src/Command/Auth/ApiTokenLoginCommand.php
@@ -1,0 +1,143 @@
+<?php
+namespace Platformsh\Cli\Command\Auth;
+
+use CommerceGuys\Guzzle\Oauth2\AccessToken;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Url;
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Service\ApiTokenStorage;
+use Platformsh\Client\OAuth2\ApiToken;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class ApiTokenLoginCommand extends CommandBase
+{
+
+    protected function configure()
+    {
+        $service = $this->config()->get('service.name');
+        $accountsUrl = $this->config()->get('service.accounts_url');
+        $executable = $this->config()->get('application.executable');
+
+        $this->setName('auth:api-token-login');
+        if ($this->config()->get('application.login_method') === 'api-token') {
+            $this->setAliases(['login']);
+        }
+
+        $this->setDescription('Log in to ' . $service . ' using an API token');
+
+        $help = 'Use this command to log in to your ' . $service . ' account using an API token.'
+            . "\n\nYou can create an account at:\n    <info>" . $accountsUrl . '</info>'
+            . "\n\nIf you have an account, but you do not already have an API token, you can create one here:\n    <info>"
+            . $accountsUrl . '/user/api-tokens</info>'
+            . "\n\nAlternatively, to log in to the CLI with a browser, run:\n    <info>"
+            . $executable . ' auth:browser-login</info>';
+        if ($aHelp = $this->getApiTokenHelp()) {
+            $help .= "\n\n" . $aHelp;
+        }
+        $this->setHelp($help);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->api()->hasApiToken(false)) {
+            $this->stdErr->writeln('Cannot log in: an API token is already set via config');
+            return 1;
+        }
+        if (!$input->isInteractive()) {
+            $this->stdErr->writeln('Non-interactive use of this command is not supported.');
+            if ($aHelp = $this->getApiTokenHelp('comment')) {
+                $this->stdErr->writeln("\n" . $aHelp);
+            }
+            return 1;
+        }
+
+        $tokenClient = new Client($this->api()->getGuzzleOptions());
+        $tokenUrl = Url::fromString($this->config()->get('api.accounts_api_url'))
+            ->combine('/oauth2/token')
+            ->__toString();
+
+        $validator = function ($apiToken) use ($tokenClient, $tokenUrl) {
+            $apiToken = trim($apiToken);
+            if (!strlen($apiToken)) {
+                throw new \RuntimeException('The token cannot be empty');
+            }
+
+            try {
+                $token = (new ApiToken($tokenClient, [
+                    'client_id' => $this->config()->get('api.oauth2_client_id'),
+                    'token_url' => $tokenUrl,
+                    'auth_location' => 'headers',
+                    'api_token' => $apiToken,
+                ]))->getToken();
+            } catch (BadResponseException $e) {
+                if ($this->exceptionMeansInvalidToken($e)) {
+                    throw new \RuntimeException('Invalid API token');
+                }
+                throw $e;
+            }
+
+            // Finalise login.
+            $this->stdErr->writeln('');
+            $this->stdErr->writeln('The API token is valid.');
+            $this->saveTokens($apiToken, $token);
+
+            return $apiToken;
+        };
+
+        /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+        $questionHelper = $this->getService('question_helper');
+        $question = new Question("Please enter an API token:\n> ");
+        $question->setValidator($validator);
+        $question->setMaxAttempts(5);
+        $questionHelper->ask($input, $output, $question);
+
+        $info = $this->api()->getClient(false, true)->getAccountInfo();
+        if (isset($info['username'], $info['mail'])) {
+            $this->stdErr->writeln('');
+            $this->stdErr->writeln(sprintf(
+                'You are logged in as <info>%s</info> (%s).',
+                $info['username'],
+                $info['mail']
+            ));
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param string      $apiToken
+     * @param AccessToken $accessToken
+     */
+    private function saveTokens($apiToken, AccessToken $accessToken) {
+        /** @var ApiTokenStorage $storage */
+        $storage = $this->getService('api_token_storage');
+        $storage->storeToken($apiToken);
+        $this->api()->getClient(false, true)->getConnector()->saveToken($accessToken);
+
+        /** @var \Doctrine\Common\Cache\CacheProvider $cache */
+        $cache = $this->getService('cache');
+        $cache->flushAll();
+    }
+
+    /**
+     * @param \Exception $e
+     *
+     * @return bool
+     */
+    private function exceptionMeansInvalidToken(\Exception $e) {
+        if (!$e instanceof BadResponseException || !$e->getResponse() || $e->getResponse()->getStatusCode() !== 400) {
+            return false;
+        }
+        $json = $e->getResponse()->json();
+        if (isset($json['error'], $json['error_description'])
+            && $json['error'] === 'invalid_grant'
+            && stripos($json['error_description'], 'Invalid API token') !== false) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Command/Auth/LogoutCommand.php
+++ b/src/Command/Auth/LogoutCommand.php
@@ -2,6 +2,7 @@
 namespace Platformsh\Cli\Command\Auth;
 
 use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Service\ApiTokenStorage;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,9 +23,14 @@ class LogoutCommand extends CommandBase
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // Ignore API tokens for this command.
-        if ($this->api()->hasApiToken()) {
-            $this->stdErr->writeln('<comment>Warning: an API token is set</comment>');
+        if ($this->api()->hasApiToken(false)) {
+            $this->stdErr->writeln('<comment>Warning: an API token is set via config</comment>');
         }
+
+        // Delete stored API token(s).
+        /** @var ApiTokenStorage $storage */
+        $storage = $this->getService('api_token_storage');
+        $storage->deleteToken();
 
         // Log out.
         $this->api()->getClient(false)

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -31,6 +31,9 @@ class Api
     /** @var \Doctrine\Common\Cache\CacheProvider */
     protected $cache;
 
+    /** @var ApiTokenStorage */
+    private $apiTokenStorage;
+
     /** @var EventDispatcherInterface */
     public $dispatcher;
 
@@ -67,16 +70,19 @@ class Api
     /**
      * Constructor.
      *
-     * @param Config|null                $config
-     * @param CacheProvider|null            $cache
+     * @param Config|null $config
+     * @param CacheProvider|null $cache
+     * @param ApiTokenStorage|null $apiTokenStorage
      * @param EventDispatcherInterface|null $dispatcher
      */
     public function __construct(
         Config $config = null,
         CacheProvider $cache = null,
+        ApiTokenStorage $apiTokenStorage = null,
         EventDispatcherInterface $dispatcher = null
     ) {
         $this->config = $config ?: new Config();
+        $this->apiTokenStorage = $apiTokenStorage ?: new ApiTokenStorage($this->config);
         $this->dispatcher = $dispatcher ?: new EventDispatcher();
 
         $this->cache = $cache ?: CacheFactory::createCacheProvider($this->config);
@@ -144,11 +150,22 @@ class Api
     /**
      * Returns whether the CLI is authenticating using an API token.
      *
+     * @param bool $includeStored
+     *
      * @return bool
      */
-    public function hasApiToken()
+    public function hasApiToken($includeStored = true)
     {
-        return isset($this->apiToken);
+        if (!$includeStored) {
+            $apiConfig = $this->config->get('api');
+
+            return isset($apiConfig['token'])
+                || isset($apiConfig['token_file'])
+                || isset($apiConfig['access_token_file'])
+                || isset($apiConfig['access_token']);
+        }
+
+        return $this->apiTokenStorage->hasToken();
     }
 
     /**
@@ -169,6 +186,55 @@ class Api
     }
 
     /**
+     * @return array
+     */
+    public function getConnectorOptions() {
+        $connectorOptions = [];
+        $connectorOptions['accounts'] = rtrim($this->config->get('api.accounts_api_url'), '/') . '/';
+        $connectorOptions['verify'] = !$this->config->get('api.skip_ssl');
+        $connectorOptions['debug'] = $this->config->get('api.debug') ? STDERR : false;
+        $connectorOptions['client_id'] = $this->config->get('api.oauth2_client_id');
+        $connectorOptions['user_agent'] = $this->getUserAgent();
+        $connectorOptions['api_token'] = $this->apiToken;
+        $connectorOptions['api_token_type'] = $this->apiTokenType;
+        $proxy = $this->getProxy();
+        if ($proxy !== null) {
+            $connectorOptions['proxy'] = $proxy;
+        }
+
+        // Override the OAuth 2.0 token and revoke URLs if provided.
+        if ($this->config->has('api.oauth2_token_url')) {
+            $connectorOptions['token_url'] = $this->config->get('api.oauth2_token_url');
+        }
+        if ($this->config->has('api.oauth2_revoke_url')) {
+            $connectorOptions['revoke_url'] = $this->config->get('api.oauth2_revoke_url');
+        }
+
+        return $connectorOptions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getGuzzleOptions() {
+        $options = [
+            'defaults' => [
+                'headers' => ['User-Agent' => $this->getUserAgent()],
+                'debug' => $this->config->get('api.debug') ? STDERR : false,
+                'verify' => !$this->config->get('api.skip_ssl'),
+                'proxy' => $this->getProxy(),
+            ],
+        ];
+
+        if (extension_loaded('zlib')) {
+            $options['defaults']['decode_content'] = true;
+            $options['defaults']['headers']['Accept-Encoding'] = 'gzip';
+        }
+
+        return $options;
+    }
+
+    /**
      * Get the API client object.
      *
      * @param bool $autoLogin Whether to log in, if the client is not already
@@ -180,28 +246,7 @@ class Api
     public function getClient($autoLogin = true, $reset = false)
     {
         if (!isset(self::$client) || $reset) {
-            $connectorOptions = [];
-            $connectorOptions['accounts'] = rtrim($this->config->get('api.accounts_api_url'), '/') . '/';
-            $connectorOptions['verify'] = !$this->config->get('api.skip_ssl');
-            $connectorOptions['debug'] = $this->config->get('api.debug') ? STDERR : false;
-            $connectorOptions['client_id'] = $this->config->get('api.oauth2_client_id');
-            $connectorOptions['user_agent'] = $this->getUserAgent();
-            $connectorOptions['api_token'] = $this->apiToken;
-            $connectorOptions['api_token_type'] = $this->apiTokenType;
-            $proxy = $this->getProxy();
-            if ($proxy !== null) {
-                $connectorOptions['proxy'] = $proxy;
-            }
-
-            // Override the OAuth 2.0 token and revoke URLs if provided.
-            if ($this->config->has('api.oauth2_token_url')) {
-                $connectorOptions['token_url'] = $this->config->get('api.oauth2_token_url');
-            }
-            if ($this->config->has('api.oauth2_revoke_url')) {
-                $connectorOptions['revoke_url'] = $this->config->get('api.oauth2_revoke_url');
-            }
-
-            $connector = new Connector($connectorOptions);
+            $connector = new Connector($this->getConnectorOptions());
 
             // Set up a persistent session to store OAuth2 tokens. By default,
             // this will be stored in a JSON file:
@@ -219,6 +264,13 @@ class Api
             // @todo move this to the Session
             if (!$session->getData()) {
                 $session->load(true);
+            }
+
+            // Load an API token from storage, if there is one saved.
+            if ($this->apiTokenStorage->hasToken()) {
+                $this->apiToken = $this->apiTokenStorage->getToken();
+                $this->apiTokenType = 'exchange';
+                $connector->setApiToken($this->apiToken, $this->apiTokenType);
             }
 
             self::$client = new PlatformClient($connector);

--- a/src/Service/ApiTokenStorage.php
+++ b/src/Service/ApiTokenStorage.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Platformsh\Cli\Service;
+
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+
+/**
+ * Stores and retrieves an API token.
+ */
+class ApiTokenStorage
+{
+    private $config;
+    private $data = [];
+    private $loaded = false;
+
+    /**
+     * @param Config $config
+     */
+    public function __construct(Config $config) {
+        $this->config = $config;
+    }
+
+    /**
+     * Checks if an API token is saved.
+     *
+     * @return bool
+     */
+    public function hasToken() {
+        $this->load();
+
+        return isset($this->data['apiToken']);
+    }
+
+    /**
+     * Loads the API token.
+     *
+     * @return string
+     */
+    public function getToken() {
+        $this->load();
+        if (!isset($this->data['apiToken'])) {
+            throw new \RuntimeException('No API token found');
+        }
+
+        return $this->data['apiToken'];
+    }
+
+    /**
+     * Stores an API token.
+     *
+     * @param string $value
+     */
+    public function storeToken($value) {
+        $this->load();
+        $this->data['apiToken'] = $value;
+        $this->save();
+    }
+
+    /**
+     * Deletes the saved token.
+     */
+    public function deleteToken() {
+        unset($this->data['apiToken']);
+        $this->save();
+    }
+
+    /**
+     * Saves data.
+     */
+    private function save() {
+        $filename = $this->getFilename();
+        $fs = new SymfonyFilesystem();
+        if (empty($this->data)) {
+            if (file_exists($filename)) {
+                $fs->remove($filename);
+            }
+            return;
+        }
+        $fs->dumpFile($filename, $this->data['apiToken']);
+    }
+
+    /**
+     * Loads stored data.
+     */
+    private function load() {
+        if (!$this->loaded) {
+            $filename = $this->getFilename();
+            if (file_exists($filename)) {
+                $this->data['apiToken'] = trim((string) file_get_contents($filename));
+            }
+            $this->loaded = true;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private function getFilename() {
+        return $this->config->getUserConfigDir() . '/' . $this->config->getWithDefault('application.api_token_file', '.api-token');
+    }
+}


### PR DESCRIPTION
Helping API tokens to be used as an alternative to password login, being deprecated in #850 

- [ ] sort out save location (conflicting or not with the api.token_file configuration)
- [ ] will this be recommended when the user is prompted to log in?
- [ ] will this allow non-interactive use? will environment variables be de-emphasised?
- [ ] refactor