### PR TITLE
Improve --activate in push command

### DIFF
--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -104,10 +104,9 @@ class EnvironmentPushCommand extends CommandBase
             $target
         ));
 
-        $activate = false;
-        $parentId = null;
         if ($target !== 'master') {
             // Determine whether to activate the environment.
+            $activate = false;
             if (!$targetEnvironment || $targetEnvironment->status === 'inactive') {
                 $activate = $input->getOption('branch')
                     || $input->getOption('activate');


### PR DESCRIPTION
Now --activate activates or branches before pushing.

The --branch option is no longer needed, so it's deprecated. It does the same thing as --activate.