### PR TITLE
Hide worker containers on enterprise

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -886,11 +886,6 @@ abstract class CommandBase extends Command implements MultiAwareInterface
 
         $environment = $this->getSelectedEnvironment();
 
-        // Enterprise environments do not have separate containers for workers.
-        if ($includeWorkers && $environment->deployment_target === 'enterprise') {
-            $includeWorkers = false;
-        }
-
         try {
             $deployment = $this->api()->getCurrentDeployment(
                 $environment,
@@ -976,6 +971,12 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             );
 
             return $this->remoteContainer = new RemoteContainer\Worker($deployment->getWorker($workerName), $environment);
+        }
+
+        // Enterprise environments do not have separate containers for workers.
+        // Disable interactive selection of worker.
+        if ($includeWorkers && $environment->deployment_target !== 'local') {
+            $includeWorkers = false;
         }
 
         // Prompt the user to choose between the app(s) or worker(s) that have

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -886,7 +886,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
 
         $environment = $this->getSelectedEnvironment();
 
-        // Enterprise environments do not have seperate containers for workers.
+        // Enterprise environments do not have separate containers for workers.
         if ($includeWorkers && $environment->deployment_target === 'enterprise') {
             $includeWorkers = false;
         }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -885,6 +885,12 @@ abstract class CommandBase extends Command implements MultiAwareInterface
         }
 
         $environment = $this->getSelectedEnvironment();
+
+        // Enterprise environments do not have seperate containers for workers.
+        if ($includeWorkers && $environment->deployment_target === 'enterprise') {
+            $includeWorkers = false;
+        }
+
         try {
             $deployment = $this->api()->getCurrentDeployment(
                 $environment,


### PR DESCRIPTION
Fixes last remaining problem raised in #865 by disabling worker selection in enterprise environments.