### PR TITLE
Allow PLATFORMSH_CLI_HOME variable to override the home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Other customization is available via environment variables:
 
 * `PLATFORMSH_CLI_DEBUG`: set to 1 to enable cURL debugging. _Warning_: this will print all request information in the terminal, including sensitive access tokens.
 * `PLATFORMSH_CLI_DISABLE_CACHE`: set to 1 to disable caching
+* `PLATFORMSH_CLI_HOME`: override the home directory (inside which the .platformsh directory is stored)
 * `PLATFORMSH_CLI_NO_COLOR`: set to 1 to disable colors in output
 * `PLATFORMSH_CLI_NO_INTERACTION`: set to 1 to disable interaction (useful for scripting). _Warning_: this will bypass any confirmation questions.
 * `PLATFORMSH_CLI_SESSION_ID`: change user session (default 'default')

--- a/dist/installer.php
+++ b/dist/installer.php
@@ -47,6 +47,7 @@ if (!$isCliInclude) {
 }
 
 class Installer {
+    private $envPrefix;
     private $manifestUrl;
     private $configDir;
     private $executable;
@@ -57,8 +58,9 @@ class Installer {
     public function __construct(array $args = []) {
         $this->argv = !empty($args) ? $args : $GLOBALS['argv'];
 
-        if (getenv('PLATFORMSH_CLI_MANIFEST_URL') !== false) {
-            $this->manifestUrl = getenv('PLATFORMSH_CLI_MANIFEST_URL');
+        $this->envPrefix = 'PLATFORMSH_CLI_';
+        if (getenv($this->envPrefix . 'MANIFEST_URL') !== false) {
+            $this->manifestUrl = getenv($this->envPrefix . 'MANIFEST_URL');
         } elseif ($manifestOption = $this->getOption('manifest')) {
             $this->manifestUrl = $manifestOption;
         } else {
@@ -502,13 +504,13 @@ class Installer {
      *   The user's home directory as an absolute path, or false on failure.
      */
     private function getHomeDirectory() {
-        if ($home = getenv('HOME')) {
-            return $home;
+        $vars = [$this->envPrefix . 'HOME', 'HOME', 'USERPROFILE'];
+        foreach ($vars as $var) {
+            if ($home = getenv($var)) {
+                return realpath($home) ?: $home;
+            }
         }
-        elseif ($userProfile = getenv('USERPROFILE')) {
-            return $userProfile;
-        }
-        elseif (!empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
+        if (!empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
             return $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'];
         }
 

--- a/src/Command/Self/SelfInstallCommand.php
+++ b/src/Command/Self/SelfInstallCommand.php
@@ -2,7 +2,6 @@
 namespace Platformsh\Cli\Command\Self;
 
 use Platformsh\Cli\Command\CommandBase;
-use Platformsh\Cli\Service\Filesystem;
 use Platformsh\Cli\Util\OsUtil;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -129,7 +128,7 @@ EOT
 
         $configDirRelative = $this->config()->getUserConfigDir(false);
         $rcDestination = $configDirRelative . '/' . 'shell-config.rc';
-        $suggestedShellConfig = 'HOME=${HOME:-' . escapeshellarg(Filesystem::getHomeDirectory()) . '}';
+        $suggestedShellConfig = 'HOME=${HOME:-' . escapeshellarg($this->config()->getHomeDirectory()) . '}';
         $suggestedShellConfig .= PHP_EOL . sprintf(
             'export PATH=%s:"$PATH"',
             '"$HOME/"' . escapeshellarg($configDirRelative . '/bin')
@@ -297,7 +296,7 @@ EOT
         // Replace the home directory with ~, if not on Windows.
         if (DIRECTORY_SEPARATOR !== '\\') {
             $realpath = realpath($filename);
-            $homeDir = Filesystem::getHomeDirectory();
+            $homeDir = $this->config()->getHomeDirectory();
             if ($realpath && strpos($realpath, $homeDir) === 0) {
                 $arg = '~/' . ltrim(substr($realpath, strlen($homeDir)), '/');
             }
@@ -326,7 +325,7 @@ EOT
         if (getcwd() === dirname($filename)) {
             return basename($filename);
         }
-        $homeDir = Filesystem::getHomeDirectory();
+        $homeDir = $this->config()->getHomeDirectory();
         if (strpos($filename, $homeDir) === 0) {
             return str_replace($homeDir, '~', $filename);
         }
@@ -348,7 +347,7 @@ EOT
         $envPrefix = $this->config()->get('service.env_prefix');
         if (getenv($envPrefix . 'PROJECT') !== false
             && getenv($envPrefix . 'APP_DIR') !== false
-            && getenv($envPrefix . 'APP_DIR') === Filesystem::getHomeDirectory()) {
+            && getenv($envPrefix . 'APP_DIR') === $this->config()->getHomeDirectory()) {
             return getenv($envPrefix . 'APP_DIR') . '/.environment';
         }
 
@@ -370,7 +369,7 @@ EOT
             array_unshift($candidates, '.zprofile');
         }
 
-        $homeDir = Filesystem::getHomeDirectory();
+        $homeDir = $this->config()->getHomeDirectory();
         foreach ($candidates as $candidate) {
             if (file_exists($homeDir . DIRECTORY_SEPARATOR . $candidate)) {
                 $this->debug('Found existing config file: ' . $homeDir . DIRECTORY_SEPARATOR . $candidate);

--- a/src/Command/SshKey/SshKeyAddCommand.php
+++ b/src/Command/SshKey/SshKeyAddCommand.php
@@ -30,8 +30,6 @@ class SshKeyAddCommand extends CommandBase
 
         $publicKeyPath = $input->getArgument('path');
         if (empty($publicKeyPath)) {
-            /** @var \Platformsh\Cli\Service\Filesystem $fs */
-            $fs = $this->getService('fs');
             $defaultKeyPath = $this->config()->getHomeDirectory() . '/.ssh/' . self::DEFAULT_BASENAME;
             $defaultPublicKeyPath = $defaultKeyPath . '.pub';
 

--- a/src/Command/SshKey/SshKeyAddCommand.php
+++ b/src/Command/SshKey/SshKeyAddCommand.php
@@ -32,7 +32,7 @@ class SshKeyAddCommand extends CommandBase
         if (empty($publicKeyPath)) {
             /** @var \Platformsh\Cli\Service\Filesystem $fs */
             $fs = $this->getService('fs');
-            $defaultKeyPath = $fs->getHomeDirectory() . '/.ssh/' . self::DEFAULT_BASENAME;
+            $defaultKeyPath = $this->config()->getHomeDirectory() . '/.ssh/' . self::DEFAULT_BASENAME;
             $defaultPublicKeyPath = $defaultKeyPath . '.pub';
 
             // Look for an existing local key.
@@ -180,9 +180,7 @@ class SshKeyAddCommand extends CommandBase
                 ? str_replace('.key', '.' . $number . 'key', $basename)
                 : $basename . '.' . $number;
         }
-        /** @var \Platformsh\Cli\Service\Filesystem $fs */
-        $fs = $this->getService('fs');
-        $filename = $fs->getHomeDirectory() . '/.ssh/' . $basename;
+        $filename = $this->config()->getHomeDirectory() . '/.ssh/' . $basename;
         if (file_exists($filename)) {
             return $this->getNewKeyPath(++$number);
         }

--- a/src/Service/Drush.php
+++ b/src/Service/Drush.php
@@ -67,7 +67,7 @@ class Drush
 
     public function getHomeDir()
     {
-        return $this->homeDir ?: Filesystem::getHomeDirectory();
+        return $this->homeDir ?: $this->config->getHomeDirectory();
     }
 
     /**

--- a/src/Service/Filesystem.php
+++ b/src/Service/Filesystem.php
@@ -117,26 +117,6 @@ class Filesystem
     }
 
     /**
-     * @return string The absolute path to the user's home directory
-     */
-    public static function getHomeDirectory()
-    {
-        foreach (['HOME', 'USERPROFILE'] as $envVar) {
-            if ($value = getenv($envVar)) {
-                if (!is_dir($value)) {
-                    throw new \RuntimeException(
-                        sprintf('Invalid environment variable %s: %s (not a directory)', $envVar, $value)
-                    );
-                }
-
-                return $value;
-            }
-        }
-
-        throw new \RuntimeException('Could not determine home directory');
-    }
-
-    /**
      * @param string $dir
      * @param int $mode
      */

--- a/src/Service/State.php
+++ b/src/Service/State.php
@@ -85,6 +85,6 @@ class State
      */
     protected function getFilename()
     {
-        return Filesystem::getHomeDirectory() . '/' . $this->config->get('application.user_state_file');
+        return $this->config->getHomeDirectory() . '/' . $this->config->get('application.user_state_file');
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -18,6 +18,19 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(123, $config->getWithDefault('nonexistent', 123));
     }
 
+    public function testGetHomeDirectory()
+    {
+        $homeDir = (new Config(['HOME' => '.']))->getHomeDirectory();
+        $this->assertNotEmpty($homeDir, 'Home directory returned');
+        $this->assertNotEquals('.', $homeDir, 'Home directory not relative');
+
+        $homeDir = (new Config(['PLATFORMSH_CLI_HOME' => __DIR__ . '/data', 'HOME' => __DIR__]))->getHomeDirectory();
+        $this->assertEquals(__DIR__ . '/data', $homeDir, 'Home directory overridden');
+
+        $homeDir = (new Config(['PLATFORMSH_CLI_HOME' => '', 'HOME' => __DIR__]))->getHomeDirectory();
+        $this->assertEquals(__DIR__, $homeDir, 'Empty value treated as nonexistent');
+    }
+
     /**
      * Test that selected environment variables can override initial config.
      */

--- a/tests/Service/FilesystemServiceTest.php
+++ b/tests/Service/FilesystemServiceTest.php
@@ -34,16 +34,6 @@ class FilesystemServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test FilesystemHelper::getHomeDirectory().
-     */
-    public function testGetHomeDirectory()
-    {
-        $homeDir = $this->fs->getHomeDirectory();
-        $this->assertNotEmpty($homeDir, 'Home directory returned');
-        $this->assertNotEmpty(realpath($homeDir), 'Home directory exists');
-    }
-
-    /**
      * Test FilesystemHelper::remove() on directories.
      */
     public function testRemoveDir()


### PR DESCRIPTION
Mainly intended to help in environments where a home directory may not be available.