### PR TITLE
Pipe to command in db:size to avoid quoting issues on Windows

### DIFF
--- a/src/Model/Host/HostInterface.php
+++ b/src/Model/Host/HostInterface.php
@@ -20,9 +20,12 @@ interface HostInterface
     public function getCacheKey();
 
     /**
+     * Runs a command on the host.
+     *
      * @param string $command
-     * @param bool   $mustRun
-     * @param bool   $quiet
+     * @param bool $mustRun
+     * @param bool $quiet
+     * @param string|null $input
      *
      * @return string|true
      *   The command's output, or true if it succeeds with no output, or false
@@ -31,7 +34,7 @@ interface HostInterface
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      *   If $mustRun is enabled and the command fails.
      */
-    public function runCommand($command, $mustRun = true, $quiet = true);
+    public function runCommand($command, $mustRun = true, $quiet = true, $input = null);
 
     /**
      * Runs a command using the current STDIN, STDOUT and STDERR.

--- a/src/Model/Host/LocalHost.php
+++ b/src/Model/Host/LocalHost.php
@@ -60,9 +60,9 @@ class LocalHost implements HostInterface
     /**
      * {@inheritDoc}
      */
-    public function runCommand($command, $mustRun = true, $quiet = true)
+    public function runCommand($command, $mustRun = true, $quiet = true, $input = null)
     {
-        return $this->shell->execute($command, null, $mustRun, $quiet);
+        return $this->shell->execute($command, null, $mustRun, $quiet, [], 3600, $input);
     }
 
     /**

--- a/src/Model/Host/RemoteHost.php
+++ b/src/Model/Host/RemoteHost.php
@@ -39,9 +39,9 @@ class RemoteHost implements HostInterface
     /**
      * {@inheritDoc}
      */
-    public function runCommand($command, $mustRun = true, $quiet = true)
+    public function runCommand($command, $mustRun = true, $quiet = true, $input = null)
     {
-        return $this->shell->execute($this->wrapCommandLine($command), null, $mustRun, $quiet);
+        return $this->shell->execute($this->wrapCommandLine($command), null, $mustRun, $quiet, [], 3600, $input);
     }
 
     /**


### PR DESCRIPTION
Quoting an SQL query inside a `mysql` command inside an `ssh` command on Windows appears to be too much trouble.