### PR TITLE
Attempt to display the Platform.sh Git URL after project creation

### DIFF
--- a/src/Command/Project/ProjectCreateCommand.php
+++ b/src/Command/Project/ProjectCreateCommand.php
@@ -196,6 +196,7 @@ EOF
         $this->stdErr->writeln("  Project ID: <info>{$subscription->project_id}</info>");
         $this->stdErr->writeln("  Project title: <info>{$subscription->project_title}</info>");
         $this->stdErr->writeln("  URL: <info>{$subscription->project_ui}</info>");
+        $this->stdErr->writeln("  Git URL: <info>{$gitRoot}</info>");
 
         $project = $this->api()->getProject($subscription->project_id);
         if ($setRemote && $gitRoot !== false && $project !== false) {


### PR DESCRIPTION
I believe this is important information to show to the user when the set-remote option is not used.