### PR TITLE
Supply SSH options to mount:upload and mount:download commands

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -103,7 +103,7 @@ services:
 
     rsync:
       class:     '\Platformsh\Cli\Service\Rsync'
-      arguments: ['@shell']
+      arguments: ['@shell', '@ssh']
 
     self_updater:
         class:     '\Platformsh\Cli\Service\SelfUpdater'

--- a/src/Command/Mount/MountDownloadCommand.php
+++ b/src/Command/Mount/MountDownloadCommand.php
@@ -5,6 +5,7 @@ namespace Platformsh\Cli\Command\Mount;
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Local\LocalApplication;
 use Platformsh\Cli\Model\RemoteContainer\App;
+use Platformsh\Cli\Service\Ssh;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,6 +34,7 @@ class MountDownloadCommand extends CommandBase
         $this->addProjectOption();
         $this->addEnvironmentOption();
         $this->addRemoteContainerOptions();
+        Ssh::configureInput($this->getDefinition());
     }
 
     /**

--- a/src/Command/Mount/MountUploadCommand.php
+++ b/src/Command/Mount/MountUploadCommand.php
@@ -4,6 +4,7 @@ namespace Platformsh\Cli\Command\Mount;
 
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Local\LocalApplication;
+use Platformsh\Cli\Service\Ssh;
 use Platformsh\Cli\Util\OsUtil;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -30,6 +31,7 @@ class MountUploadCommand extends CommandBase
         $this->addProjectOption();
         $this->addEnvironmentOption();
         $this->addRemoteContainerOptions();
+        Ssh::configureInput($this->getDefinition());
     }
 
     /**

--- a/src/Service/Rsync.php
+++ b/src/Service/Rsync.php
@@ -2,6 +2,9 @@
 
 namespace Platformsh\Cli\Service;
 
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
 /**
  * Helper class which runs rsync.
  */
@@ -9,15 +12,32 @@ class Rsync
 {
 
     private $shell;
+    private $ssh;
 
     /**
      * Constructor.
      *
      * @param Shell|null $shellHelper
+     * @param Ssh|null $ssh
      */
-    public function __construct(Shell $shellHelper = null)
+    public function __construct(Shell $shellHelper = null, Ssh $ssh = null)
     {
         $this->shell = $shellHelper ?: new Shell();
+        $this->ssh = $ssh ?: new Ssh(new ArrayInput([]), new NullOutput());
+    }
+
+    /**
+     * Returns environment variables for configuring rsync.
+     *
+     * @return array
+     */
+    private function env() {
+        $env = [];
+        if ($this->ssh->getSshArgs() !== []) {
+            $env['RSYNC_RSH'] = $this->ssh->getSshCommand();
+        }
+
+        return $env;
     }
 
     /**
@@ -104,6 +124,6 @@ class Rsync
             }
         }
 
-        $this->shell->execute($params, null, true, false, [], null);
+        $this->shell->execute($params, null, true, false, $this->env(), null);
     }
 }


### PR DESCRIPTION
This allows specifying an SSH key with the --identity-file (-i) option to the mount:download and mount:upload commands.

Resolves #880 