### PR TITLE
replace foo/bar example with username/repository

### DIFF
--- a/src/Command/Integration/IntegrationCommandBase.php
+++ b/src/Command/Integration/IntegrationCommandBase.php
@@ -185,8 +185,8 @@ abstract class IntegrationCommandBase extends CommandBase
                     'bitbucket_server',
                     'github',
                 ]],
-                'description' => 'The repository to track (e.g. \'username/repository\')',
-                'questionLine' => 'The repository (e.g. \'username/repository\')',
+                'description' => 'The repository to track (e.g. \'owner/repository\')',
+                'questionLine' => 'The repository (e.g. \'owner/repository\')',
                 'validator' => function ($string) {
                     return substr_count($string, '/', 1) === 1;
                 },

--- a/src/Command/Integration/IntegrationCommandBase.php
+++ b/src/Command/Integration/IntegrationCommandBase.php
@@ -185,8 +185,8 @@ abstract class IntegrationCommandBase extends CommandBase
                     'bitbucket_server',
                     'github',
                 ]],
-                'description' => 'The repository to track (e.g. \'foo/bar\')',
-                'questionLine' => 'The repository (e.g. \'foo/bar\')',
+                'description' => 'The repository to track (e.g. \'username/repository\')',
+                'questionLine' => 'The repository (e.g. \'username/repository\')',
                 'validator' => function ($string) {
                     return substr_count($string, '/', 1) === 1;
                 },


### PR DESCRIPTION
If username/repository doesn't work, we could go with a simplified version:

- user/repo
- username/repo

what do you think? Thanks! 
