### PR TITLE
Add redeploy warnings to the user:add and user:delete commands

### DIFF
--- a/src/Command/User/UserAddCommand.php
+++ b/src/Command/User/UserAddCommand.php
@@ -294,24 +294,24 @@ class UserAddCommand extends CommandBase
                     } else {
                         continue;
                     }
-                } else {
-                    if ($access) {
-                        if ($access->role === $role) {
-                            continue;
-                        }
-                        $this->stdErr->writeln("Setting the user's role on the environment <info>$environmentId</info> to: $role");
-                        $result = $access->update(['role' => $role]);
-                    } else {
-                        $this->stdErr->writeln("Adding the user to the environment: <info>$environmentId</info>");
-                        $result = $environment->addUser($userId, $role);
+                } elseif ($access) {
+                    if ($access->role === $role) {
+                        continue;
                     }
+                    $this->stdErr->writeln("Setting the user's role on the environment <info>$environmentId</info> to: $role");
+                    $result = $access->update(['role' => $role]);
+                } else {
+                    $this->stdErr->writeln("Adding the user to the environment: <info>$environmentId</info>");
+                    $result = $environment->addUser($userId, $role);
                 }
                 $activities = array_merge($activities, $result->getActivities());
             }
         }
 
         // Wait for activities to complete.
-        if ($this->shouldWait($input)) {
+        if (!$activities) {
+            $this->redeployWarning();
+        } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             if (!$activityMonitor->waitMultiple($activities, $project)) {

--- a/src/Command/User/UserDeleteCommand.php
+++ b/src/Command/User/UserDeleteCommand.php
@@ -53,7 +53,9 @@ class UserDeleteCommand extends CommandBase
 
         $this->stdErr->writeln("User <info>$email</info> deleted");
 
-        if ($this->shouldWait($input)) {
+        if (!$result->getActivities()) {
+            $this->redeployWarning();
+        } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
             $activityMonitor = $this->getService('activity_monitor');
             $activityMonitor->waitMultiple($result->getActivities(), $project);


### PR DESCRIPTION
If redeploys are not automatically triggered, a warning is printed, e.g.:

```
User foo@example.com deleted

The remote environment(s) must be redeployed for the change to take effect.
To redeploy an environment, run: platform redeploy
```