### PR TITLE
Add mbstring to required extensions

### DIFF
--- a/dist/installer.php
+++ b/dist/installer.php
@@ -120,6 +120,7 @@ class Installer {
         );
 
         $required_extensions = [
+            'mbstring',
             'openssl',
             'pcre',
         ];


### PR DESCRIPTION
Without this extension running the `platform workers` command just give
you an output like:

```
Workers on the project xxx (xxx), environment Master (master):
```

But without any output of the workers on the environment or errors.
Running it with verbose mode give you more info:

```
Fatal error: Uncaught Error: Call to undefined function Symfony\Polyfill\Mbstring\iconv() in phar:///root/.platformsh/bin/platform/vendor/symfony/polyfill-mbstring/Mbstring.php:713
Stack trace:
 #0 phar:///root/.platformsh/bin/platform/vendor/symfony/polyfill-mbstring/bootstrap.php(102): Symfony\Polyfill\Mbstring\Mbstring::mb_strwidth('app--queue', 'ASCII')
 #1 phar:///root/.platformsh/bin/platform/vendor/symfony/console/Helper/Helper.php(54): mb_strwidth('app--queue', 'ASCII')
 #2 phar:///root/.platformsh/bin/platform/vendor/symfony/console/Helper/Helper.php(123): Symfony\Component\Console\Helper\Helper::strlen('app--queue')
 #3 phar:///root/.platformsh/bin/platform/src/Console/AdaptiveTable.php(353): Symfony\Component\Console\Helper\Helper::strlenWithoutDecoration(Object(Symfony\Component\Console\Formatter\OutputFormatter), 'app--queue')
 #4 phar:///root/.platformsh/bin/platform/src/Console/AdaptiveTable.php(267): Platformsh\Cli\Console\AdaptiveTable->getCellWidth('app--queue')
 #5 phar:///root/.platformsh/bin/platform/src/Co in phar:///root/.platformsh/bin/platform/vendor/symfony/polyfill-mbstring/Mbstring.php on line 713
```

env: LANG=C.UTF-8

Adding the `php-mbstring` extension fixed the issue

ref https://github.com/platformsh/platformsh-cli/issues/955#issuecomment-659991333