### PR TITLE
Use ed25519 SSH certificates/keys and regenerate keys every time

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.24 <2.0",
-        "platformsh/client": ">=0.35.2 <2.0",
+        "platformsh/client": ">=0.36.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34395bedceaf33b0af253532c389a178",
+    "content-hash": "03de151b12695c9fcb5d188f166d1ab6",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -665,16 +665,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "v0.35.2",
+            "version": "0.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "ce7f949dc6788ee90b8172d991845a5a66788531"
+                "reference": "6e7421d309e94f33627d14064609079a24cde06f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/ce7f949dc6788ee90b8172d991845a5a66788531",
-                "reference": "ce7f949dc6788ee90b8172d991845a5a66788531",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/6e7421d309e94f33627d14064609079a24cde06f",
+                "reference": "6e7421d309e94f33627d14064609079a24cde06f",
                 "shasum": ""
             },
             "require": {
@@ -704,7 +704,7 @@
                 }
             ],
             "description": "Platform.sh API client",
-            "time": "2020-07-21T07:54:05+00:00"
+            "time": "2020-07-24T10:34:31+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Command/SshCert/SshCertLoadCommand.php
+++ b/src/Command/SshCert/SshCertLoadCommand.php
@@ -15,12 +15,14 @@ class SshCertLoadCommand extends CommandBase
             ->setName('ssh-cert:load')
             ->addOption('refresh-only', null, InputOption::VALUE_NONE, 'Only refresh the certificate, if necessary (do not write SSH config)')
             ->addOption('new', null, InputOption::VALUE_NONE, 'Force the certificate to be refreshed')
-            ->addOption('new-key', null, InputOption::VALUE_NONE, 'Force the certificate to be refreshed with a new SSH key pair')
+            ->addOption('new-key', null, InputOption::VALUE_NONE, '[Deprecated] Use --new instead')
             ->setDescription('Generate an SSH certificate');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->warnAboutDeprecatedOptions(['new-key'], 'The --new-key option is deprecated. Use --new instead.');
+
         // Initialize the API service to ensure event listeners etc.
         $this->api();
 
@@ -42,7 +44,7 @@ class SshCertLoadCommand extends CommandBase
 
         if ($refresh) {
             $this->stdErr->writeln('Generating SSH certificate...');
-            $sshCert = $certifier->generateCertificate($input->getOption('new-key'));
+            $sshCert = $certifier->generateCertificate();
             $this->displayCertificate($sshCert);
         }
 

--- a/src/SshCert/Certifier.php
+++ b/src/SshCert/Certifier.php
@@ -11,7 +11,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Certifier
 {
-    const PRIVATE_KEY_FILENAME = 'id_rsa';
+    const KEY_ALGORITHM = 'ed25519';
+    const PRIVATE_KEY_FILENAME = 'id_ed25519';
 
     private $api;
     private $config;
@@ -114,7 +115,7 @@ class Certifier
             $this->fs->remove($sshInfo);
         }
         // Generate new keys and set permissions.
-        $this->shell->execute(['ssh-keygen', '-t', 'rsa', '-N', '', '-f', $sshInfo['private']], null, true);
+        $this->shell->execute(['ssh-keygen', '-t', self::KEY_ALGORITHM, '-N', '', '-f', $sshInfo['private']], null, true);
         $this->chmod($sshInfo['private'], 0600);
         $this->chmod($sshInfo['public'], 0600);
 

--- a/src/SshCert/Certifier.php
+++ b/src/SshCert/Certifier.php
@@ -41,16 +41,14 @@ class Certifier
     /**
      * Generates a new certificate.
      *
-     * @param bool $newKeyPair Whether to recreate the SSH key pair.
-     *
      * @return Certificate
      */
-    public function generateCertificate($newKeyPair = false)
+    public function generateCertificate()
     {
         $dir = $this->config->getSessionDir(true) . DIRECTORY_SEPARATOR . 'ssh';
         $this->fs->mkdir($dir, 0700);
 
-        $sshPair = $this->generateSshKey($dir, $newKeyPair);
+        $sshPair = $this->generateSshKey($dir, true);
         $publicContents = file_get_contents($sshPair['public']);
         if (!$publicContents) {
             throw new \RuntimeException('Failed to read public key file: ' . $publicContents);


### PR DESCRIPTION
Regenerating RSA keys takes on average 200ms for me (between around 60ms and 400ms)

Regenerating ED25519 keys takes a small fraction of that, around ~1ms or less.

ED25519 was available from OpenSSH 6.5 (January 2014).

The CertificateFile option (which we are already using) was available from OpenSSH 7.2 (February 2016).