### PR TITLE
Revamp config to no longer need an Accounts URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.24 <2.0",
-        "platformsh/client": ">=0.36.0 <2.0",
+        "platformsh/client": ">=0.37.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03de151b12695c9fcb5d188f166d1ab6",
+    "content-hash": "9c416469b99b1e5972dfdd22496ab13d",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -665,16 +665,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.36.0",
+            "version": "v0.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "6e7421d309e94f33627d14064609079a24cde06f"
+                "reference": "25bf621a37fefb18a7a0ea94202ac7163209a962"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/6e7421d309e94f33627d14064609079a24cde06f",
-                "reference": "6e7421d309e94f33627d14064609079a24cde06f",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/25bf621a37fefb18a7a0ea94202ac7163209a962",
+                "reference": "25bf621a37fefb18a7a0ea94202ac7163209a962",
                 "shasum": ""
             },
             "require": {
@@ -704,7 +704,7 @@
                 }
             ],
             "description": "Platform.sh API client",
-            "time": "2020-07-24T10:34:31+00:00"
+            "time": "2020-07-28T11:48:53+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/config.yaml
+++ b/config.yaml
@@ -85,7 +85,10 @@ service:
   applications_config_file: '.platform/applications.yaml'
   docs_url: 'https://docs.platform.sh'
   docs_search_url: 'https://www.google.com/search?q=site%3Adocs.platform.sh%20{{ terms }}'
-  accounts_url: 'https://accounts.platform.sh'
+  api_tokens_url: 'https://accounts.platform.sh/user/api-tokens'
+  register_url: 'https://auth.api.platform.sh'
+  reset_password_url: 'https://auth.api.platform.sh/reset-password'
+  console_url: 'https://console.platform.sh'
   pricing_url: 'https://platform.sh/pricing'
   api_token_help_url: 'https://docs.platform.sh/gettingstarted/cli/api-tokens.html'
   available_regions:
@@ -112,9 +115,6 @@ api:
 
   # Overridden by {application.env_prefix}API_URL env var.
   base_url: 'https://api.platform.sh/'
-
-  # Overridden by {application.env_prefix}ACCOUNTS_API env var.
-  accounts_api_url: 'https://accounts.platform.sh/api/v1/'
 
   # Overridden by {application.env_prefix}OAUTH2_AUTH_URL env var.
   oauth2_auth_url:  'https://auth.api.platform.sh/oauth2/authorize'

--- a/src/Command/Auth/ApiTokenLoginCommand.php
+++ b/src/Command/Auth/ApiTokenLoginCommand.php
@@ -17,7 +17,6 @@ class ApiTokenLoginCommand extends CommandBase
     protected function configure()
     {
         $service = $this->config()->get('service.name');
-        $accountsUrl = $this->config()->get('service.accounts_url');
         $executable = $this->config()->get('application.executable');
 
         $this->setName('auth:api-token-login');
@@ -28,9 +27,9 @@ class ApiTokenLoginCommand extends CommandBase
         $this->setDescription('Log in to ' . $service . ' using an API token');
 
         $help = 'Use this command to log in to your ' . $service . ' account using an API token.'
-            . "\n\nYou can create an account at:\n    <info>" . $accountsUrl . '</info>'
+            . "\n\nYou can create an account at:\n    <info>" . $this->config()->get('service.register_url') . '</info>'
             . "\n\nIf you have an account, but you do not already have an API token, you can create one here:\n    <info>"
-            . $accountsUrl . '/user/api-tokens</info>'
+            . $this->config()->get('service.api_tokens_url') . '</info>'
             . "\n\nAlternatively, to log in to the CLI with a browser, run:\n    <info>"
             . $executable . ' auth:browser-login</info>';
         $this->setHelp($help);

--- a/src/Command/Auth/PasswordLoginCommand.php
+++ b/src/Command/Auth/PasswordLoginCommand.php
@@ -15,7 +15,6 @@ class PasswordLoginCommand extends CommandBase
     protected function configure()
     {
         $service = $this->config()->get('service.name');
-        $accountsUrl = $this->config()->get('service.accounts_url');
         $executable = $this->config()->get('application.executable');
 
         $this->setName('auth:password-login');
@@ -27,9 +26,9 @@ class PasswordLoginCommand extends CommandBase
         $this->setDescription('Log in to ' . $service . ' using a username and password');
 
         $help = 'Use this command to log in to your ' . $service . ' account in the terminal.'
-            . "\n\nYou can create an account at:\n    <info>" . $accountsUrl . '</info>'
+            . "\n\nYou can create an account at:\n    <info>" . $this->config()->get('service.register_url') . '</info>'
             . "\n\nIf you have an account, but you do not already have a password, you can set one here:\n    <info>"
-            . $accountsUrl . '/user/password</info>'
+            . $this->config()->get('service.reset_password_url') . '</info>'
             . "\n\nAlternatively, to log in to the CLI with a browser, run:\n    <info>"
             . $executable . ' auth:browser-login</info>'
             . "\n\n" . $this->getNonInteractiveAuthHelp();
@@ -134,7 +133,7 @@ class PasswordLoginCommand extends CommandBase
                     '<error>Login failed. Please check your credentials.</error>',
                     '',
                     "Forgot your password? Or don't have a password yet? Visit:",
-                    '  <comment>' . $this->config()->get('service.accounts_url') . '/user/password</comment>',
+                    '  <comment>' . $this->config()->get('service.reset_password_url') . '</comment>',
                     '',
                 ]);
                 $this->configureAccount($input, $output);

--- a/src/Command/WebCommand.php
+++ b/src/Command/WebCommand.php
@@ -48,7 +48,7 @@ class WebCommand extends CommandBase
                 }
             }
         } else {
-            $url = $this->config()->get('service.accounts_url');
+            $url = $this->config()->getWithDefault('service.console_url', $this->config()->get('service.accounts_url'));
         }
 
         /** @var \Platformsh\Cli\Service\Url $urlService */

--- a/src/Command/WelcomeCommand.php
+++ b/src/Command/WelcomeCommand.php
@@ -90,9 +90,7 @@ class WelcomeCommand extends CommandBase
             $messages = [];
             $messages[] = '<comment>This project is suspended.</comment>';
             if ($project->owner === $this->api()->getMyAccount()['id']) {
-                $messages[] = '<comment>Update your payment details to re-activate it: '
-                    . $this->config()->get('service.accounts_url')
-                    . '</comment>';
+                $messages[] = '<comment>Update your payment details to re-activate it</comment>';
             }
             $messages[] = '';
             $this->stdErr->writeln($messages);

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -246,7 +246,6 @@ class Api
      */
     private function getConnectorOptions() {
         $connectorOptions = [];
-        $connectorOptions['accounts'] = rtrim($this->config->get('api.accounts_api_url'), '/') . '/';
         $connectorOptions['api_url'] = $this->config->getWithDefault('api.base_url', '');
         $connectorOptions['certifier_url'] = $this->config->get('api.certifier_url');
         $connectorOptions['verify'] = !$this->config->get('api.skip_ssl');
@@ -728,7 +727,7 @@ class Api
     {
         $data = $this->getMyAccount($reset);
 
-        return SshKey::wrapCollection($data['ssh_keys'], rtrim($this->config->get('api.accounts_api_url'), '/') . '/', $this->getHttpClient());
+        return SshKey::wrapCollection($data['ssh_keys'], rtrim($this->config->get('api.base_url'), '/') . '/', $this->getHttpClient());
     }
 
     /**

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -309,8 +309,6 @@ class Config
             'SESSION_ID' => 'api.session_id',
             'SKIP_SSL' => 'api.skip_ssl',
             'API_URL' => 'api.base_url',
-            'ACCOUNTS_API' => 'api.accounts_api_url',
-            'ACCOUNTS_API_URL' => 'api.accounts_api_url',
             'OAUTH2_AUTH_URL' => 'api.oauth2_auth_url',
             'OAUTH2_TOKEN_URL' => 'api.oauth2_token_url',
             'OAUTH2_REVOKE_URL' => 'api.oauth2_revoke_url',


### PR DESCRIPTION
Removes `service.accounts_url` and `api.accounts_api_url` from `config.yaml`.

API access will instead be based on:
```yaml
api:
  # ...
  base_url: 'https://api.platform.sh'
  oauth2_auth_url:  'https://auth.api.platform.sh/oauth2/authorize'
  oauth2_token_url:  'https://auth.api.platform.sh/oauth2/token'
  oauth2_revoke_url:  'https://auth.api.platform.sh/oauth2/revoke'
  certifier_url: 'https://ssh.api.platform.sh'
```

Various user-facing URL strings are under `service`:
```yaml
service:
  # ...
  docs_url: 'https://docs.platform.sh'
  docs_search_url: 'https://www.google.com/search?q=site%3Adocs.platform.sh%20{{ terms }}'
  api_tokens_url: 'https://accounts.platform.sh/user/api-tokens'
  register_url: 'https://auth.api.platform.sh'
  reset_password_url: 'https://auth.api.platform.sh/reset-password'
  console_url: 'https://console.platform.sh'
  pricing_url: 'https://platform.sh/pricing'
  api_token_help_url: 'https://docs.platform.sh/gettingstarted/cli/api-tokens.html'
```