### PR TITLE
Ignore project-level variable activities

### DIFF
--- a/src/Command/Project/Variable/ProjectVariableSetCommand.php
+++ b/src/Command/Project/Variable/ProjectVariableSetCommand.php
@@ -62,21 +62,14 @@ class ProjectVariableSetCommand extends CommandBase
         }
 
         // Set the variable to a new value.
-        $result = $this->getSelectedProject()
+        $this->getSelectedProject()
                        ->setVariable($variableName, $variableValue, $json, !$supressBuild, !$supressRuntime);
 
         $this->stdErr->writeln("Variable <info>$variableName</info> set to: $variableValue");
 
-        $success = true;
-        if (!$result->countActivities()) {
-            $this->redeployWarning();
-        } elseif ($this->shouldWait($input)) {
-            /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
-            $activityMonitor = $this->getService('activity_monitor');
-            $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());
-        }
+        $this->redeployWarning();
 
-        return $success ? 0 : 1;
+        return 0;
     }
 
     /**

--- a/src/Command/Variable/VariableCreateCommand.php
+++ b/src/Command/Variable/VariableCreateCommand.php
@@ -155,7 +155,7 @@ class VariableCreateCommand extends VariableCommandBase
         $this->displayVariable($result->getEntity());
 
         $success = true;
-        if (!$result->countActivities()) {
+        if (!$result->countActivities() || $level === self::LEVEL_PROJECT) {
             $this->redeployWarning();
         } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */

--- a/src/Command/Variable/VariableDeleteCommand.php
+++ b/src/Command/Variable/VariableDeleteCommand.php
@@ -81,7 +81,7 @@ class VariableDeleteCommand extends VariableCommandBase
         $this->stdErr->writeln("Deleted variable <info>$variableName</info>");
 
         $success = true;
-        if (!$result->countActivities()) {
+        if (!$result->countActivities() || $level === self::LEVEL_PROJECT) {
             $this->redeployWarning();
         } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */

--- a/src/Command/Variable/VariableUpdateCommand.php
+++ b/src/Command/Variable/VariableUpdateCommand.php
@@ -84,7 +84,8 @@ class VariableUpdateCommand extends VariableCommandBase
         $this->displayVariable($variable);
 
         $success = true;
-        if (!$result->countActivities()) {
+
+        if (!$result->countActivities() || $level === self::LEVEL_PROJECT) {
             $this->redeployWarning();
         } elseif ($this->shouldWait($input)) {
             /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */


### PR DESCRIPTION
Variable changes at the project level are going to generate activities, but environments are still not automatically redeployed. This PR removes the assumption that an activity is a redeploy. The "redeploy warning" will now be shown when project-level variables are changed or deleted, regardless of whether activities are generated.