### PR TITLE
Detect the SSH version and show appropriate messages

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1633,9 +1633,11 @@ abstract class CommandBase extends Command implements MultiAwareInterface
         $this->stdErr->writeln('You are logged in.');
 
         // Generate a new certificate from the certifier API.
+        /** @var \Platformsh\Cli\Service\SshConfig $sshConfig */
+        $sshConfig = $this->getService('ssh_config');
         /** @var \Platformsh\Cli\SshCert\Certifier $certifier */
         $certifier = $this->getService('certifier');
-        if ($certifier->isAutoLoadEnabled()) {
+        if ($certifier->isAutoLoadEnabled() && $sshConfig->checkRequiredVersion()) {
             $this->stdErr->writeln('');
             $this->stdErr->writeln('Generating SSH certificate...');
             try {
@@ -1650,8 +1652,6 @@ abstract class CommandBase extends Command implements MultiAwareInterface
         // Write SSH configuration.
         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
         $questionHelper = $this->getService('question_helper');
-        /** @var \Platformsh\Cli\Service\SshConfig $sshConfig */
-        $sshConfig = $this->getService('ssh_config');
         if ($sshConfig->configureSessionSsh()) {
             $sshConfig->addUserSshConfig($questionHelper);
         }

--- a/src/Command/SshCert/SshCertInfoCommand.php
+++ b/src/Command/SshCert/SshCertInfoCommand.php
@@ -29,12 +29,17 @@ class SshCertInfoCommand extends CommandBase
 
         /** @var \Platformsh\Cli\SshCert\Certifier $certifier */
         $certifier = $this->getService('certifier');
+        /** @var \Platformsh\Cli\Service\SshConfig $sshConfig */
+        $sshConfig = $this->getService('ssh_config');
 
         $cert = $certifier->getExistingCertificate();
         if (!$cert || !$this->isValid($cert)) {
             if ($input->getOption('no-refresh')) {
                 $this->stdErr->writeln('No valid SSH certificate found.');
                 $this->stdErr->writeln('To generate a certificate, run this command again without the <comment>--no-refresh</comment> option.');
+                return 1;
+            }
+            if (!$sshConfig->checkRequiredVersion()) {
                 return 1;
             }
             // Generate a new certificate.

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -382,11 +382,15 @@ class SshConfig {
         $this->openSshVersion = false;
         $process = new Process('ssh -V');
         $process->run();
+        $errorOutput = $process->getErrorOutput();
         if (!$process->isSuccessful()) {
+            if ($this->stdErr->isVerbose()) {
+                $this->stdErr->writeln('Unable to determine the installed OpenSSH version. The command output was:');
+                $this->stdErr->writeln($errorOutput);
+            }
             return false;
         }
-        $stdErr = $process->getErrorOutput();
-        if (\preg_match('/OpenSSH_([0-9.]+[^ ,]*)/', $stdErr, $matches)) {
+        if (\preg_match('/OpenSSH_([0-9.]+[^ ,]*)/', $errorOutput, $matches)) {
             $this->openSshVersion = $matches[1];
         }
         return $this->openSshVersion;
@@ -437,7 +441,6 @@ class SshConfig {
     {
         $version = $this->findVersion();
         if (!$version) {
-            $this->stdErr->writeln('Unable to determine the installed OpenSSH version.', OutputInterface::VERBOSITY_VERBOSE);
             return true;
         }
         if (\version_compare($version, '6.5', '<')) {

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -386,7 +386,7 @@ class SshConfig {
             return false;
         }
         $stdErr = $process->getErrorOutput();
-        if (\preg_match('/OpenSSH_([0-9.]+[^ ]*)/', $stdErr, $matches)) {
+        if (\preg_match('/OpenSSH_([0-9.]+[^ ,]*)/', $stdErr, $matches)) {
             $this->openSshVersion = $matches[1];
         }
         return $this->openSshVersion;


### PR DESCRIPTION
Addresses #966 

- Skips adding SSH config/include files if the version is below 7.3 (and shows a message recommending 7.3+)
- Skips using `CertificateFile` if the version is below 7.2 (and shows a message recommending 7.3+)
- Fails to generate a certificate at all if the version is below 6.5 (and shows a message recommending 7.3+)