### PR TITLE
Github Actions workflow to build platform.sh CLI phar executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      
+
     - name: Get Composer Cache Directory
       id: composer-cache
       run: |
         echo "::set-output name=dir::$(composer config cache-files-dir)"
-  
+
     - uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
@@ -30,12 +30,12 @@ jobs:
         composer install --no-dev --no-interaction
         cd vendor-bin/box
         composer install --no-interaction
-        
+
     - name: Symlink vendor/bin/box
       run: |
        mkdir -p vendor/bin
        ln -s "$(realpath vendor-bin/box/vendor/bin/box)" vendor/bin/box
-       
+
     - name: Build platform.phar
       env:
         CI_COMMIT_SHA: ${{ github.event.after }}
@@ -43,7 +43,7 @@ jobs:
       run: |
         CI_COMMIT_SHORT_SHA=$(echo $CI_COMMIT_SHA | head -c8)
         ./bin/platform self:build --no-composer-rebuild --yes --replace-version "$CI_COMMIT_REF_NAME"-"$CI_COMMIT_SHORT_SHA" --output platform.phar
-    
+
     - uses: actions/upload-artifact@v2
       with:
         name: cli-phar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    env:
-      COMPOSER_HOME: /home/runner/.composer/cache
-
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      COMPOSER_HOME: /home/runner/.composer/cache
+      COMPOSER_HOME: /github/workspace/composer
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,22 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      COMPOSER_HOME: /github/workspace/composer
+      COMPOSER_HOME: /home/runner/.composer/cache
 
     steps:
     - uses: actions/checkout@v2
+      
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: |
+        echo "::set-output name=dir::$(composer config cache-files-dir)"
+  
+    - uses: actions/cache@v2
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,17 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
-      with:
-        path: /github/workspace/composer
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
     - name: Install dependencies
       run: |
         composer install --no-dev --no-interaction
         cd vendor-bin/box
         composer install --no-interaction
+        
     - name: Symlink vendor/bin/box
       run: |
        mkdir -p vendor/bin
        ln -s "$(realpath vendor-bin/box/vendor/bin/box)" vendor/bin/box
+       
     - name: Build platform.phar
       env:
         CI_COMMIT_SHA: ${{ github.event.after }}
@@ -36,6 +31,7 @@ jobs:
       run: |
         CI_COMMIT_SHORT_SHA=$(echo $CI_COMMIT_SHA | head -c8)
         ./bin/platform self:build --no-composer-rebuild --yes --replace-version "$CI_COMMIT_REF_NAME"-"$CI_COMMIT_SHORT_SHA" --output platform.phar
+    
     - uses: actions/upload-artifact@v2
       with:
         name: cli-phar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      COMPOSER_HOME: /cache/composer
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        composer install --no-dev --no-interaction
+        cd vendor-bin/box
+        composer install --no-interaction
+    - name: Symlink vendor/bin/box
+      run: |
+       mkdir -p vendor/bin
+       ln -s "$(realpath vendor-bin/box/vendor/bin/box)" vendor/bin/box
+    - name: Build platform.phar
+      env:
+        CI_COMMIT_SHA: ${{ github.event.after }}
+      run: |
+        CI_COMMIT_SHORT_SHA=$(echo $CI_COMMIT_SHA | head -c8)
+        ./bin/platform self:build --no-composer-rebuild --yes --replace-version "$CI_COMMIT_SHORT_SHA" --output platform.phar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: cli-phar
+        path: platform.phar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,10 @@ jobs:
     - name: Build platform.phar
       env:
         CI_COMMIT_SHA: ${{ github.event.after }}
+        CI_COMMIT_REF_NAME: ${{ github.head_ref }}
       run: |
         CI_COMMIT_SHORT_SHA=$(echo $CI_COMMIT_SHA | head -c8)
-        ./bin/platform self:build --no-composer-rebuild --yes --replace-version "$CI_COMMIT_SHORT_SHA" --output platform.phar
+        ./bin/platform self:build --no-composer-rebuild --yes --replace-version "$CI_COMMIT_REF_NAME"-"$CI_COMMIT_SHORT_SHA" --output platform.phar
     - uses: actions/upload-artifact@v2
       with:
         name: cli-phar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      COMPOSER_HOME: /cache/composer
+      COMPOSER_HOME: /home/runner/.composer/cache
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: actions/cache@v2
+      with:
+        path: /github/workspace/composer
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
     - name: Install dependencies
       run: |
         composer install --no-dev --no-interaction


### PR DESCRIPTION
### Summary

This PR adds Github Actions workflow to build the platform CLI phar executable file. The build steps are taken from [.gitlab-ci.yml](https://github.com/platformsh/platformsh-cli/blob/master/.gitlab-ci.yml) with minor tweaks to work with Github Actions.

```
    - name: Build platform.phar
      env:
        CI_COMMIT_SHA: ${{ github.event.after }}
        CI_COMMIT_REF_NAME: ${{ github.head_ref }}
      run: |
        CI_COMMIT_SHORT_SHA=$(echo $CI_COMMIT_SHA | head -c8)
        ./bin/platform self:build --no-composer-rebuild --yes --replace-version "$CI_COMMIT_REF_NAME"-"$CI_COMMIT_SHORT_SHA" --output platform.phar
```

### Tests
- [x] Workflow runs successfully
- [x] Phar executable artifact runs on local machine

### Screenshots
![Screen Shot 2020-08-24 at 12 55 29](https://user-images.githubusercontent.com/5674762/91014751-ad037300-e609-11ea-8bce-3930a800a937.png)
![Screen Shot 2020-08-24 at 12 57 40](https://user-images.githubusercontent.com/5674762/91014764-b096fa00-e609-11ea-970f-8dea7470e676.png)
