### PR TITLE
Generate a cleaner ssh config file

### DIFF
--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -85,15 +85,6 @@ class SshConfig {
             $lines[] = '';
         }
 
-        $sessionSpecificFilename = $this->getSessionSshDir() . DIRECTORY_SEPARATOR . 'config';
-        $includerFilename = $this->getCliSshDir() . DIRECTORY_SEPARATOR . 'session.config';
-        if (empty($lines)) {
-            if (\file_exists($includerFilename) || \file_exists($sessionSpecificFilename)) {
-                $this->fs->remove([$includerFilename, $sessionSpecificFilename]);
-            }
-            return false;
-        }
-
         // Add default files if there is no preferred session identity file.
         if ($sessionIdentityFile === null && ($defaultFiles = $this->getUserDefaultSshIdentityFiles())) {
             $lines[] = '# Include SSH "default" identity files:';
@@ -102,6 +93,15 @@ class SshConfig {
                 $lines[] = sprintf('IdentityFile %s', $identityFile);
             }
             $lines[] = '';
+        }
+
+        $sessionSpecificFilename = $this->getSessionSshDir() . DIRECTORY_SEPARATOR . 'config';
+        $includerFilename = $this->getCliSshDir() . DIRECTORY_SEPARATOR . 'session.config';
+        if (empty($lines)) {
+            if (\file_exists($includerFilename) || \file_exists($sessionSpecificFilename)) {
+                $this->fs->remove([$includerFilename, $sessionSpecificFilename]);
+            }
+            return false;
         }
 
         $this->writeSshIncludeFile($sessionSpecificFilename, $lines);

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -71,12 +71,15 @@ class SshConfig {
             $lines[] = '';
         }
 
+
+        $hostBlock = '';
         if ($domainWildcards) {
-            $lines[] = 'Host ' . implode(' ', $domainWildcards);
+            $hostBlock = 'Host ' . implode(' ', $domainWildcards);
         }
 
         $sessionIdentityFile = $this->sshKey->selectIdentity();
         if ($sessionIdentityFile !== null) {
+            $lines[] = $hostBlock;
             $lines[] = '# This SSH key was detected as corresponding to the session:';
             $lines[] = sprintf('IdentityFile %s', $sessionIdentityFile);
             $lines[] = '';
@@ -95,6 +98,7 @@ class SshConfig {
         if ($sessionIdentityFile === null && ($defaultFiles = $this->getUserDefaultSshIdentityFiles())) {
             $lines[] = '# Include SSH "default" identity files:';
             foreach ($defaultFiles as $identityFile) {
+                $lines[] = $hostBlock;
                 $lines[] = sprintf('IdentityFile %s', $identityFile);
             }
             $lines[] = '';


### PR DESCRIPTION
These changes make the config file generated a bit cleaner in some cases. It's also now possible to determine that no config need be generated at all.