### PR TITLE
Do not display "You probably need to add an SSH key" if the authentication succeeded

### DIFF
--- a/src/Service/SshDiagnostics.php
+++ b/src/Service/SshDiagnostics.php
@@ -84,9 +84,10 @@ class SshDiagnostics
         if (!$reset && isset($this->connectionTestResult)) {
             return $this->connectionTestResult;
         }
-        $this->stdErr->writeln('Making test connection to diagnose SSH errors', OutputInterface::VERBOSITY_VERBOSE);
+        $this->stdErr->writeln('Making test connection to diagnose SSH errors', OutputInterface::VERBOSITY_DEBUG);
         $process = new Process($this->ssh->getSshCommand([], $uri, 'exit'));
         $process->run();
+        $this->stdErr->writeln('Test connection complete', OutputInterface::VERBOSITY_DEBUG);
         return $this->connectionTestResult = $process;
     }
 


### PR DESCRIPTION
This occurs if the SSH key or certificate was correct, but the requested service does not exist or the user does not have access to it.