### PR TITLE
Stop using SSH home directory substitution

### DIFF
--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -133,9 +133,6 @@ class SshConfig {
      */
     public function formatFilePath($path)
     {
-        // Replace the home directory with the SSH token %d, which solves most quoting problems.
-        $home = $this->config->getHomeDirectory();
-        $path = \str_replace($home, '%d', $path);
         if (\strpos($path, ' ') === false) {
             return $path;
         }

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -127,17 +127,24 @@ class SshConfig {
      * This should be applied to the IdentityFile and CertificateFile option
      * values. See the ssh_config(5) man page: https://www.freebsd.org/cgi/man.cgi?ssh_config%285%29
      *
+     * Note: a previous version of this method replaced the home directory with
+     * SSH's percent syntax (%d). However, this does not work on systems where
+     * the HOME environment variable is set to a directory other than the
+     * current user's (notably on GitHub Actions containers), because the
+     * OpenSSH client does not support reading HOME.
+     *
      * @param string $path
      *
      * @return string
      */
     public function formatFilePath($path)
     {
-        if (\strpos($path, ' ') === false) {
-            return $path;
+        // Escape paths containing a space.
+        if (\strpos($path, ' ') !== false) {
+            // The three quote marks in the middle mean: end quote, literal quote mark, start quote.
+            return '"' . \str_replace('"', '"""', $path) . '"';
         }
-        // The three quote marks in the middle mean: end quote, literal quote mark, start quote.
-        return '"' . \str_replace('"', '"""', $path) . '"';
+        return $path;
     }
 
     /**


### PR DESCRIPTION
This PR is based on a bug found running the CLI inside GitHub Actions:

1. The Platform.sh CLI passes certificate/key filenames to ssh using `%d` to substitute for the home directory, mostly for neatness, and to bypass some shell path quoting issues on Windows (e.g. when the user name contains a space) (https://github.com/platformsh/platformsh-cli/blob/fbb54779c624be881a35ce82da53df07141513ce/src/Service/SshConfig.php#L136-L138)
2. GitHub Actions sets the home directory via the `$HOME` environment variable to `/github/home`
3. The Platform.sh CLI reads `$HOME` as you'd expect
4. However, ssh (OpenSSH) picks up the home directory using's C's `getpwuid(getuid())`, which uses the user database (`/etc/passwd`) directly, and it ignores the `$HOME` environment variable: https://github.com/openssh/openssh-portable/blob/eab2888cfc6cc4e2ef24bd017da9835a0f365f3f/ssh.c#L682
4. Therefore the `ssh` process in GitHub Actions believes the home directory is `/root`, so it can't find the SSH certificate stored in `/github/home`

Reported via chat - https://platformsh.slack.com/archives/C0JHEUHQD/p1603307475289200