### PR TITLE
 Add activity:cancel command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.24 <2.0",
-        "platformsh/client": ">=0.39.0 <2.0",
+        "platformsh/client": ">=0.40.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.24 <2.0",
-        "platformsh/client": ">=0.38.1 <2.0",
+        "platformsh/client": ">=0.39.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a18b032106e42883b145cc8981c2be62",
+    "content-hash": "94fe3085045ceb9184018fae20a4b048",
     "packages": [
         {
             "name": "cocur/slugify",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94fe3085045ceb9184018fae20a4b048",
+    "content-hash": "38f2f40058a67146cbfb6ef4c1775cb7",
     "packages": [
         {
             "name": "cocur/slugify",

--- a/src/Application.php
+++ b/src/Application.php
@@ -99,6 +99,7 @@ class Application extends ParentApplication
         $commands[] = new Command\DocsCommand();
         $commands[] = new Command\LegacyMigrateCommand();
         $commands[] = new Command\MultiCommand();
+        $commands[] = new Command\Activity\ActivityCancelCommand();
         $commands[] = new Command\Activity\ActivityGetCommand();
         $commands[] = new Command\Activity\ActivityListCommand();
         $commands[] = new Command\Activity\ActivityLogCommand();

--- a/src/Command/Activity/ActivityCancelCommand.php
+++ b/src/Command/Activity/ActivityCancelCommand.php
@@ -5,6 +5,8 @@ use GuzzleHttp\Exception\BadResponseException;
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Service\ActivityLoader;
 use Platformsh\Cli\Service\ActivityMonitor;
+use Platformsh\Cli\Service\PropertyFormatter;
+use Platformsh\Cli\Service\QuestionHelper;
 use Platformsh\Client\Model\Activity;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -56,13 +58,14 @@ class ActivityCancelCommand extends CommandBase
                 }
             }
         } else {
-            $activities = $loader->loadFromInput($apiResource, $input, 1, [Activity::STATE_PENDING, Activity::STATE_IN_PROGRESS], 'cancel');
+            $activities = $loader->loadFromInput($apiResource, $input, 10, [Activity::STATE_PENDING, Activity::STATE_IN_PROGRESS], 'cancel');
             if ($activities === false) {
                 return 1;
             }
-            /** @var Activity $activity */
-            $activity = reset($activities);
-            if (!$activity) {
+            $activities = \array_filter($activities, function (Activity $activity) {
+                return $activity->operationAvailable('cancel');
+            });
+            if (\count($activities) === 0) {
                 $this->stdErr->writeln('No cancellable activities found');
 
                 $this->stdErr->writeln('');
@@ -70,6 +73,24 @@ class ActivityCancelCommand extends CommandBase
 
                 return 1;
             }
+            $choices = [];
+            /** @var QuestionHelper $questionHelper */
+            $questionHelper = $this->getService('question_helper');
+            /** @var PropertyFormatter $formatter */
+            $formatter = $this->getService('property_formatter');
+            $byId = [];
+            $this->api()->sortResources($activities, 'created_at');
+            foreach ($activities as $activity) {
+                $byId[$activity->id] = $activity;
+                $choices[$activity->id] = \sprintf(
+                    '%s: %s (%s)',
+                    $formatter->formatDate($activity->created_at),
+                    ActivityMonitor::getFormattedDescription($activity),
+                    ActivityMonitor::formatState($activity->state)
+                );
+            }
+            $id = $questionHelper->choose($choices, 'Enter a number to choose an activity to cancel:', key($choices), true);
+            $activity = $byId[$id];
         }
 
         $this->stdErr->writeln(sprintf(
@@ -82,6 +103,7 @@ class ActivityCancelCommand extends CommandBase
             $activity->cancel();
         } catch (BadResponseException $e) {
             if ($e->getResponse() && $e->getResponse()->getStatusCode() === 400 && \strpos($e->getMessage(), 'cannot be cancelled in its current state')) {
+                $activity->refresh();
                 $this->stdErr->writeln(\sprintf('The activity cannot be cancelled in its current state (<error>%s</error>).', $activity->state));
                 $this->stdErr->writeln('');
                 $this->stdErr->writeln(\sprintf("To view this activity's log, run: <comment>%s activity:log %s</comment>", $executable, $activity->id));

--- a/src/Command/Activity/ActivityCancelCommand.php
+++ b/src/Command/Activity/ActivityCancelCommand.php
@@ -1,0 +1,102 @@
+<?php
+namespace Platformsh\Cli\Command\Activity;
+
+use GuzzleHttp\Exception\BadResponseException;
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Service\ActivityLoader;
+use Platformsh\Cli\Service\ActivityMonitor;
+use Platformsh\Client\Model\Activity;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ActivityCancelCommand extends CommandBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('activity:cancel')
+            ->setDescription('Cancel an activity')
+            ->addArgument('id', InputArgument::OPTIONAL, 'The activity ID. Defaults to the most recent cancellable activity.')
+            ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter by type (when selecting a default activity)')
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Check recent activities on all environments (when selecting a default activity)');
+        $this->addProjectOption()
+            ->addEnvironmentOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->validateInput($input, $input->getOption('all') || $input->getArgument('id'));
+
+        /** @var ActivityLoader $loader */
+        $loader = $this->getService('activity_loader');
+
+        $executable = $this->config()->get('application.executable');
+
+        if ($this->hasSelectedEnvironment() && !$input->getOption('all')) {
+            $apiResource = $this->getSelectedEnvironment();
+        } else {
+            $apiResource = $this->getSelectedProject();
+        }
+
+        $id = $input->getArgument('id');
+        if ($id) {
+            $activity = $this->getSelectedProject()
+                ->getActivity($id);
+            if (!$activity) {
+                $activity = $this->api()->matchPartialId($id, $loader->loadFromInput($apiResource, $input, 10, [Activity::STATE_PENDING, Activity::STATE_IN_PROGRESS], 'cancel') ?: [], 'Activity');
+                if (!$activity) {
+                    $this->stdErr->writeln("Activity not found: <error>$id</error>");
+
+                    return 1;
+                }
+            }
+        } else {
+            $activities = $loader->loadFromInput($apiResource, $input, 1, [Activity::STATE_PENDING, Activity::STATE_IN_PROGRESS], 'cancel');
+            if ($activities === false) {
+                return 1;
+            }
+            /** @var Activity $activity */
+            $activity = reset($activities);
+            if (!$activity) {
+                $this->stdErr->writeln('No cancellable activities found');
+
+                $this->stdErr->writeln('');
+                $this->stdErr->writeln(\sprintf('To list incomplete activities, run: <info>%s act -i</info>', $executable));
+
+                return 1;
+            }
+        }
+
+        $this->stdErr->writeln(sprintf(
+            'Cancelling the activity <info>%s</info> (%s)...',
+            $activity->id,
+            ActivityMonitor::getFormattedDescription($activity)
+        ));
+
+        try {
+            $activity->cancel();
+        } catch (BadResponseException $e) {
+            if ($e->getResponse() && $e->getResponse()->getStatusCode() === 400 && \strpos($e->getMessage(), 'cannot be cancelled in its current state')) {
+                $this->stdErr->writeln(\sprintf('The activity cannot be cancelled in its current state (<error>%s</error>).', $activity->state));
+                $this->stdErr->writeln('');
+                $this->stdErr->writeln(\sprintf("To view this activity's log, run: <comment>%s activity:log %s</comment>", $executable, $activity->id));
+                return 1;
+            }
+            throw $e;
+        }
+
+        $this->stdErr->writeln('');
+        $this->stdErr->writeln('The activity was successfully cancelled.');
+
+        $this->stdErr->writeln('');
+        $this->stdErr->writeln(\sprintf("To view this activity's log, run: <info>%s activity:log %s</info>", $executable, $activity->id));
+        $this->stdErr->writeln(\sprintf('To list all activities, run: <info>%s act</info>', $executable));
+
+        return 0;
+    }
+}

--- a/src/Command/Backup/BackupListCommand.php
+++ b/src/Command/Backup/BackupListCommand.php
@@ -49,7 +49,7 @@ class BackupListCommand extends CommandBase
 
         /** @var \Platformsh\Cli\Service\ActivityLoader $loader */
         $loader = $this->getService('activity_loader');
-        $activities = $loader->load($environment, $input->getOption('limit'), 'environment.backup', $startsAt);
+        $activities = $loader->load($environment, $input->getOption('limit'), 'environment.backup', $startsAt, 'complete', 'success');
         if (!$activities) {
             $this->stdErr->writeln('No backups found');
             return 1;

--- a/src/Command/Backup/BackupRestoreCommand.php
+++ b/src/Command/Backup/BackupRestoreCommand.php
@@ -38,7 +38,7 @@ class BackupRestoreCommand extends CommandBase
 
         $backupName = $input->getArgument('backup');
         if (!empty($backupName)) {
-            $backupActivities = $loader->load($environment, null, 'environment.backup', null, function (Activity $activity) use ($backupName) {
+            $backupActivities = $loader->load($environment, null, 'environment.backup', null, 'complete', 'success', function (Activity $activity) use ($backupName) {
                 return $activity->payload['backup_name'] === $backupName;
             });
             // Find the specified backup.

--- a/src/Command/Integration/Activity/IntegrationActivityListCommand.php
+++ b/src/Command/Integration/Activity/IntegrationActivityListCommand.php
@@ -26,6 +26,8 @@ class IntegrationActivityListCommand extends IntegrationCommandBase
             ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter activities by type')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of results displayed', 10)
             ->addOption('start', null, InputOption::VALUE_REQUIRED, 'Only activities created before this date will be listed')
+            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter activities by state')
+            ->addOption('result', null, InputOption::VALUE_REQUIRED, 'Filter activities by result')
             ->setDescription('Get a list of activities for an integration');
         $this->setHiddenAliases(['integration:activities']);
         Table::configureInput($this->getDefinition());
@@ -58,7 +60,7 @@ class IntegrationActivityListCommand extends IntegrationCommandBase
 
         /** @var \Platformsh\Cli\Service\ActivityLoader $loader */
         $loader = $this->getService('activity_loader');
-        $activities = $loader->load($integration, $limit, $type, $startsAt);
+        $activities = $loader->load($integration, $limit, $type, $startsAt, $input->getOption('state'), $input->getOption('result'));
         if (!$activities) {
             $this->stdErr->writeln('No activities found');
 

--- a/src/Service/ActivityLoader.php
+++ b/src/Service/ActivityLoader.php
@@ -2,8 +2,10 @@
 
 namespace Platformsh\Cli\Service;
 
-use Platformsh\Client\Model\Resource;
+use Platformsh\Client\Model\Activities\HasActivitiesInterface;
+use Platformsh\Client\Model\Activity;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -11,14 +13,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ActivityLoader
 {
 
-    private $output;
+    private $stdErr;
 
     /**
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      */
     public function __construct(OutputInterface $output)
     {
-        $this->output = $output;
+        $this->stdErr = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
     }
 
     /**
@@ -26,32 +28,65 @@ class ActivityLoader
      */
     private function getProgressOutput()
     {
-        if (!$this->output->isDecorated()) {
-            return new NullOutput();
-        }
-        if ($this->output instanceof ConsoleOutputInterface) {
-            return $this->output->getErrorOutput();
-        }
-
-        return $this->output;
+        return $this->stdErr->isDecorated() ? $this->stdErr : new NullOutput();
     }
 
     /**
-     * Load activities.
+     * Loads activities, looking at options set in a command input.
      *
-     * @param Resource    $apiResource
+     * The --state, --incomplete, --result, --start, --limit, and --type options will be processed.
+     *
+     * @param int|null $limit Limit the number of activities to return, regardless of input.
+     *
+     * @return \Platformsh\Client\Model\Activity[]|false
+     *   False if an error occurred, an array of activities otherwise.
+     */
+    public function loadFromInput(HasActivitiesInterface $apiResource, InputInterface $input, $limit = null)
+    {
+        $state = [];
+        if ($input->hasOption('state')) {
+            $state = $input->getOption('state');
+            if (\count($state) === 1) {
+                $state = \array_filter(\preg_split('/[,\s]+/', \reset($state)), '\\strlen');
+            }
+            if ($input->getOption('incomplete')) {
+                if ($state && $state != [Activity::STATE_IN_PROGRESS, Activity::STATE_PENDING]) {
+                    $this->stdErr->writeln('The <comment>--incomplete</comment> option implies <comment>--state in_progress,pending</comment>');
+                }
+                $state = [Activity::STATE_IN_PROGRESS, Activity::STATE_PENDING];
+            }
+        }
+        if ($limit === null) {
+            $limit = $input->hasOption('limit') ? $input->getOption('limit') : null;
+        }
+        $type = $input->hasOption('type') ? $input->getOption('type') : null;
+        $result = $input->hasOption('result') ? $input->getOption('result') : null;
+        $startsAt = null;
+        if ($input->hasOption('start') && $input->getOption('start') && !($startsAt = strtotime($input->getOption('start')))) {
+            $this->stdErr->writeln('Invalid --start date: <error>' . $input->getOption('start') . '</error>');
+            return [];
+        }
+        return $this->load($apiResource, $limit, $type, $startsAt, $state, $result);
+    }
+
+    /**
+     * Loads activities.
+     *
+     * @param HasActivitiesInterface    $apiResource
      * @param int|null    $limit
      * @param string|null $type
      * @param int|null    $startsAt
+     * @param string|string[]|null    $state
+     * @param string|string[]|null    $result
      * @param callable|null $stopCondition
      *   A test to perform on each activity. If it returns true, loading is stopped.
      *
      * @return \Platformsh\Client\Model\Activity[]
      */
-    public function load(Resource $apiResource, $limit, $type, $startsAt, callable $stopCondition = null)
+    public function load(HasActivitiesInterface $apiResource, $limit = null, $type = null, $startsAt = null, $state = null, $result = null, callable $stopCondition = null)
     {
         /** @var \Platformsh\Client\Model\Environment|\Platformsh\Client\Model\Project $apiResource */
-        $activities = $apiResource->getActivities($limit ?: 0, $type, $startsAt);
+        $activities = $apiResource->getActivities($limit ?: 0, $type, $startsAt, $state, $result);
         $progress = new ProgressBar($this->getProgressOutput());
         $progress->setMessage($type === 'environment.backup' ? 'Loading backups...' : 'Loading activities...');
         $progress->setFormat($limit === null ? '%message% %current%' : '%message% %current% (max: %max%)');
@@ -69,7 +104,7 @@ class ActivityLoader
             if ($activity = end($activities)) {
                 $startsAt = strtotime($activity->created_at);
             }
-            $nextActivities = $apiResource->getActivities($limit ? $limit - count($activities) : 0, $type, $startsAt);
+            $nextActivities = $apiResource->getActivities($limit ? $limit - count($activities) : 0, $type, $startsAt, $state, $result);
             $new = false;
             foreach ($nextActivities as $activity) {
                 if (!isset($activities[$activity->id])) {

--- a/src/Service/ActivityMonitor.php
+++ b/src/Service/ActivityMonitor.php
@@ -23,6 +23,7 @@ class ActivityMonitor
         Activity::STATE_PENDING => 'pending',
         Activity::STATE_COMPLETE => 'complete',
         Activity::STATE_IN_PROGRESS => 'in progress',
+        Activity::STATE_CANCELLED => 'cancelled',
     ];
 
     protected $output;


### PR DESCRIPTION
Based on #1005. Resolves #910 

- [x] Refine default behavior, i.e. the loading/filtering of "cancellable" activities. Currently, the presence of the hypermedia link is misleading. Perhaps show a choice of activities in interactive mode.