### PR TITLE
Make SSH connection error more generic

### DIFF
--- a/src/Service/SshDiagnostics.php
+++ b/src/Service/SshDiagnostics.php
@@ -205,7 +205,7 @@ class SshDiagnostics
                 $this->stdErr->writeln('');
             }
             $this->stdErr->writeln(sprintf(
-                'You probably need to add an SSH key, with: <comment>%s ssh-key:add</comment>',
+                '<error>[Could not connect]</error> Either the app is being deployed or you need to add an SSH key, with: <comment>%s ssh-key:add</comment>',
                 $executable
             ));
             return;


### PR DESCRIPTION
When booted from an SSH session during deployment users see "You probably need to add an SSH key, with: platform ssh-key:add".

This proposed change covers disconnects due to deployments.