### PR TITLE
Add --format=plain option for table commands

### DIFF
--- a/src/Util/Csv.php
+++ b/src/Util/Csv.php
@@ -62,7 +62,7 @@ class Csv
      *
      * @return string
      */
-    private function formatCell($cell)
+    protected function formatCell($cell)
     {
         // Cast cell data to a string.
         $cell = (string) $cell;

--- a/src/Util/PlainFormat.php
+++ b/src/Util/PlainFormat.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Platformsh\Cli\Util;
+
+/**
+ * A plain, line-based format intended for easy parsing on the command-line.
+ *
+ * This is similar to tab-separated values (TSV), but does not quote cells. It
+ * therefore cannot preserve newlines or tabs within cells.
+ */
+class PlainFormat extends Csv
+{
+    public function __construct() {
+        parent::__construct("\t", "\n");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function formatCell($cell) {
+        // Replace any newline or tab characters with a space.
+        return \preg_replace('#[\r\n\t]+#', ' ', (string) $cell);
+    }
+}

--- a/tests/Util/CsvTest.php
+++ b/tests/Util/CsvTest.php
@@ -3,6 +3,7 @@
 namespace Platformsh\Cli\Tests\Util;
 
 use Platformsh\Cli\Util\Csv;
+use Platformsh\Cli\Util\PlainFormat;
 
 class CsvTest extends \PHPUnit_Framework_TestCase
 {
@@ -40,6 +41,17 @@ class CsvTest extends \PHPUnit_Framework_TestCase
             . "1999\tChevy\t\"Venture \"\"Extended Edition, Very Large\"\"\"\t\t5000.00\n"
             . "1996\tJeep\tGrand Cherokee\t\"MUST SELL!\nair, moon roof, loaded\"\t4799.00";
         $actual = (new Csv("\t", "\n"))->format($this->data, false);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testPlain()
+    {
+        $expected = "Year\tMake\tModel\tDescription\tPrice\n"
+            . "1997\tFord\tE350\tac, abs, moon\t3000.00\n"
+            . "1999\tChevy\tVenture \"Extended Edition\"\t\t4900.00\n"
+            . "1999\tChevy\tVenture \"Extended Edition, Very Large\"\t\t5000.00\n"
+            . "1996\tJeep\tGrand Cherokee\tMUST SELL! air, moon roof, loaded\t4799.00";
+        $actual = (new PlainFormat())->format($this->data, false);
         $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
Intended for easy parsing with `grep` / `cut` etc., at the expense of losing newlines/tabs within cells.

Inspired by https://clig.dev/#output