### PR TITLE
integrations: Pass the user-supplied token for creating webhooks

### DIFF
--- a/src/Command/Integration/IntegrationAddCommand.php
+++ b/src/Command/Integration/IntegrationAddCommand.php
@@ -88,7 +88,7 @@ class IntegrationAddCommand extends IntegrationCommandBase
         /** @var Integration $integration */
         $integration = $result->getEntity();
 
-        $this->ensureHooks($integration);
+        $this->ensureHooks($integration, $values);
 
         $this->stdErr->writeln("Created integration <info>$integration->id</info> (type: {$values['type']})");
 


### PR DESCRIPTION
The API used to provide the token in the GET response. It now hides it, so we need to use the value the user provided on the command line when the integration was created.

This helps with creating webhooks when a GitLab or GitHub integration is added.

In the longer term, the API should be upgraded to handle webhooks itself.