### PR TITLE
Pass --fail to curl utility commands

### DIFF
--- a/src/Service/CurlCli.php
+++ b/src/Service/CurlCli.php
@@ -92,6 +92,8 @@ class CurlCli implements InputConfiguringInterface {
             $commandline .= ' --silent --show-error';
         }
 
+        $commandline .= ' --fail';
+
         $stdErr->writeln(sprintf('Running command: <info>%s</info>', str_replace($token, '[token]', $commandline)), OutputInterface::VERBOSITY_VERBOSE);
 
         $process = proc_open($commandline, [STDIN, STDOUT, STDERR], $pipes);


### PR DESCRIPTION
Makes curl return an error exit code (22) and no output, if the HTTP response status code is >= 400