### PR TITLE
Fix edge case bug

### DIFF
--- a/src/Command/Db/DbSizeCommand.php
+++ b/src/Command/Db/DbSizeCommand.php
@@ -321,7 +321,7 @@ class DbSizeCommand extends CommandBase
      */
     private function mysqlTablesInNeedOfOptimizing() {
         /*, data_free, data_length, ((data_free+1)/(data_length+1))*100 as wasted_space_percentage*/
-        return 'SELECT TABLE_SCHEMA, TABLE_NAME FROM information_schema.tables WHERE ENGINE = "InnoDB" AND ((data_free+1)/(data_length+1))*100 >= '.self::WASTED_SPACE_WARNING_THRESHOLD.' ORDER BY data_free DESC LIMIT 10';
+        return 'SELECT TABLE_SCHEMA, TABLE_NAME FROM information_schema.tables WHERE ENGINE = "InnoDB" AND TABLE_TYPE="BASE TABLE" AND ((data_free+1)/(data_length+1))*100 >= '.self::WASTED_SPACE_WARNING_THRESHOLD.' ORDER BY data_free DESC LIMIT 10';
     }
 
     /**


### PR DESCRIPTION
It is possible in an edge situation that the --cleanup flag proposes to ALTER the information_schema tables. Since those cannot be OPTIMIZED, or ALTERED this isn't supposed to happen.

I propose to add a TABLE_TYPE="base table" (as per docs : https://dev.mysql.com/doc/refman/5.7/en/information-schema-tables-table.html ) so that it only lists actual tables, and never SYSTEM VIEW tables.