### PR TITLE
Support environment types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.24 <2.0",
-        "platformsh/client": ">=0.43.0 <2.0",
+        "platformsh/client": ">=0.44.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.24 <2.0",
-        "platformsh/client": ">=0.44.0 <2.0",
+        "platformsh/client": ">=0.45.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5b665a2a0770a8c0bdcc1c074067d2e",
+    "content-hash": "5dedfc50d640ac1530ca42d493b83de0",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -730,16 +730,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.44.0",
+            "version": "0.45.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "72a741a25345791ba1991da3c7521d13ecce12b3"
+                "reference": "4dcff942a5b0c0f39d524b5f2af56a0c4333e6fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/72a741a25345791ba1991da3c7521d13ecce12b3",
-                "reference": "72a741a25345791ba1991da3c7521d13ecce12b3",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/4dcff942a5b0c0f39d524b5f2af56a0c4333e6fe",
+                "reference": "4dcff942a5b0c0f39d524b5f2af56a0c4333e6fe",
                 "shasum": ""
             },
             "require": {
@@ -771,9 +771,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.44.0"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.45.0"
             },
-            "time": "2021-06-04T11:51:50+00:00"
+            "time": "2021-06-14T08:13:20+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05238763951195a5c845a9937d952245",
+    "content-hash": "e5b665a2a0770a8c0bdcc1c074067d2e",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -730,16 +730,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.43.0",
+            "version": "0.44.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "5971107b8e3730dd5b1b759f7fd3ba596f539dd8"
+                "reference": "72a741a25345791ba1991da3c7521d13ecce12b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/5971107b8e3730dd5b1b759f7fd3ba596f539dd8",
-                "reference": "5971107b8e3730dd5b1b759f7fd3ba596f539dd8",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/72a741a25345791ba1991da3c7521d13ecce12b3",
+                "reference": "72a741a25345791ba1991da3c7521d13ecce12b3",
                 "shasum": ""
             },
             "require": {
@@ -771,9 +771,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.43.0"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.44.0"
             },
-            "time": "2021-03-26T14:54:25+00:00"
+            "time": "2021-06-04T11:51:50+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Command/Environment/EnvironmentBranchCommand.php
+++ b/src/Command/Environment/EnvironmentBranchCommand.php
@@ -20,6 +20,7 @@ class EnvironmentBranchCommand extends CommandBase
             ->addArgument('id', InputArgument::OPTIONAL, 'The ID (branch name) of the new environment')
             ->addArgument('parent', InputArgument::OPTIONAL, 'The parent of the new environment')
             ->addOption('title', null, InputOption::VALUE_REQUIRED, 'The title of the new environment')
+            ->addOption('type', null, InputOption::VALUE_REQUIRED, 'The type of the new environment')
             ->addOption(
                 'force',
                 null,
@@ -120,15 +121,27 @@ class EnvironmentBranchCommand extends CommandBase
 
         $title = $input->getOption('title') !== null ? $input->getOption('title') : $branchName;
 
+        $newLabel = strlen($title) > 0 && $title !== $branchName
+            ? '<info>' . $title . '</info> (' . $branchName . ')'
+            : '<info>' . $branchName . '</info>';
+
+        $type = $input->getOption('type');
+        if ($type !== null) {
+            $newLabel .= ' (type: <info>' . $type . '</info>)';
+        }
+
         $this->stdErr->writeln(sprintf(
             'Creating a new environment %s, branched from %s',
-            strlen($title) > 0 && $title !== $branchName
-                ? '<info>' . $title . '</info> (' . $branchName . ')'
-                : '<info>' . $branchName . '</info>',
+            $newLabel,
             $this->api()->getEnvironmentLabel($parentEnvironment)
         ));
 
-        $activity = $parentEnvironment->branch($title, $branchName, !$input->getOption('no-clone-parent'));
+        $activity = $parentEnvironment->branch(
+            $title,
+            $branchName,
+            !$input->getOption('no-clone-parent'),
+            $type
+        );
 
         // Clear the environments cache, as branching has started.
         $this->api()->clearEnvironmentsCache($selectedProject->id);

--- a/src/Command/Environment/EnvironmentInfoCommand.php
+++ b/src/Command/Environment/EnvironmentInfoCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Platformsh\Cli\Command\Environment;
 
+use GuzzleHttp\Exception\BadResponseException;
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Service\Table;
@@ -133,7 +134,19 @@ class EnvironmentInfoCommand extends CommandBase
 
             return 0;
         }
-        $result = $environment->update([$property => $value]);
+        try {
+            $result = $environment->update([$property => $value]);
+        } catch (BadResponseException $e) {
+            // Translate validation error messages.
+            if (($response = $e->getResponse()) && $response->getStatusCode() === 400 && ($body = $response->getBody())) {
+                $detail = \json_decode((string) $body, true);
+                if (\is_array($detail) && !empty($detail['detail'][$property])) {
+                    $this->stdErr->writeln("Invalid value for <error>$property</error>: " . $detail['detail'][$property]);
+                    return 1;
+                }
+            }
+            throw $e;
+        }
         $this->stdErr->writeln(sprintf(
             'Property <info>%s</info> set to: %s',
             $property,

--- a/src/Command/Environment/EnvironmentInfoCommand.php
+++ b/src/Command/Environment/EnvironmentInfoCommand.php
@@ -169,6 +169,7 @@ class EnvironmentInfoCommand extends CommandBase
             'parent' => 'string',
             'title' => 'string',
             'restrict_robots' => 'boolean',
+            'type' => 'string',
         ];
 
         return isset($writableProperties[$property]) ? $writableProperties[$property] : false;

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -1002,13 +1002,18 @@ class Api
     {
         $id = $environment->id;
         $title = $environment->title;
+        $type = $environment->getProperty('type', false);
         $use_title = strlen($title) > 0 && $title !== $id;
+        $use_type = $type !== null && $type !== $id;
         $pattern = $use_title ? '%2$s (%3$s)' : '%3$s';
         if ($tag !== false) {
             $pattern = $use_title ? '<%1$s>%2$s</%1$s> (%3$s)' : '<%1$s>%3$s</%1$s>';
         }
+        if ($use_type) {
+            $pattern .= $tag !== false ? ' (type: <%1$s>%4$s</%1$s>)' : ' (type: %4$s)';
+        }
 
-        return sprintf($pattern, $tag, $title, $id);
+        return sprintf($pattern, $tag, $title, $id, $type);
     }
 
     /**


### PR DESCRIPTION
- [x] Add the type as a column in `env:list` (where supported)
- [x] Let the type be modified in `env:info`
- [x] Add a --type option to `env:branch`
- [x] Add a --type filter option to `env:list`
- [x] Add a --type option to `push`
- [x] Add some documentation to explain some projects may not support types yet
- [ ] Support setting user roles by environment type
- Allow listing types?? (there are just the 3 hardcoded ones for now, `development`, `staging` and `production`)