### PR TITLE
Rework environment:delete --merged to not require a local Git repository

### DIFF
--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -105,32 +105,6 @@ class Git
     }
 
     /**
-     * Get a list of branches merged with a specific ref.
-     *
-     * @param string $ref
-     * @param bool   $remote
-     * @param null   $dir
-     * @param bool   $mustRun
-     *
-     * @return string[]
-     */
-    public function getMergedBranches($ref = 'HEAD', $remote = false, $dir = null, $mustRun = false)
-    {
-        $args = ['branch', '--list', '--no-column', '--no-color', '--merged', $ref];
-        if ($remote) {
-            $args[] = '--remote';
-        }
-        $online = $remote;
-        $mergedBranches = $this->execute($args, $dir, $mustRun, true, [], $online);
-        return array_map(
-            function ($element) {
-                return trim($element, ' *');
-            },
-            explode("\n", $mergedBranches)
-        );
-    }
-
-    /**
      * Execute a Git command.
      *
      * @param string[]          $args

--- a/tests/Service/GitServiceTest.php
+++ b/tests/Service/GitServiceTest.php
@@ -127,20 +127,6 @@ class GitServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test GitHelper::getMergedBranches().
-     */
-    public function testGetMergedBranches()
-    {
-        $this->git->checkOutNew('branch1');
-        $this->git->checkOutNew('branch2');
-        $this->assertEquals([
-            'branch1',
-            'branch2',
-            'main',
-        ], $this->git->getMergedBranches('main'));
-    }
-
-    /**
      * Test GitHelper::getConfig().
      */
     public function testGetConfig()


### PR DESCRIPTION
This slightly changes behavior:

```sh
platform environment:delete --merged main
```

Previously: this deletes environments merged with the `main` environment (excluding `main` itself). Not specifying `main` would cause an error if no base environment was otherwise selected.

Now: this deletes environments merged with their _own_ parent, whatever that may be, including `main` if `main` itself has a parent and is merged. Not specifying `main` makes no difference.

I expect this change is unlikely to be disruptive, because the default branch is unlikely to have a parent. Environments with children will not be deleted in any case.

This improves performance, by a few seconds for the CLI project, and simplifies the code considerably.