### PR TITLE
Removing 'master' in platform get command

### DIFF
--- a/src/Command/Project/ProjectGetCommand.php
+++ b/src/Command/Project/ProjectGetCommand.php
@@ -132,7 +132,7 @@ class ProjectGetCommand extends CommandBase
             }
 
             $this->debug('Initializing the repository');
-            $git->init($projectRoot, true);
+            $git->init($projectRoot, $project->default_branch, true);
 
             $this->debug('Initializing the project');
             $localProject->mapDirectory($projectRoot, $project);

--- a/src/Command/Project/ProjectGetCommand.php
+++ b/src/Command/Project/ProjectGetCommand.php
@@ -137,6 +137,11 @@ class ProjectGetCommand extends CommandBase
             $this->debug('Initializing the project');
             $localProject->mapDirectory($projectRoot, $project);
 
+            if($git->getCurrentBranch($projectRoot) != $project->default_branch) {
+                $this->debug('current branch does not match the default_branch, create it.');
+                $git->checkOutNew($project->default_branch, null, null, $projectRoot);
+            }
+
             $this->stdErr->writeln('');
             $this->stdErr->writeln(sprintf(
                 'Your project has been initialized and connected to <info>%s</info>!',
@@ -144,8 +149,9 @@ class ProjectGetCommand extends CommandBase
             ));
             $this->stdErr->writeln('');
             $this->stdErr->writeln(sprintf(
-                'Commit and push to the <info>master</info> branch of the <info>%s</info> Git remote'
+                'Commit and push to the <info>%s</info> branch of the <info>%s</info> Git remote'
                 . ', and %s will build your project automatically.',
+                $project->default_branch,
                 $this->config()->get('detection.git_remote_name'),
                 $this->config()->get('service.name')
             ));

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -151,13 +151,17 @@ class Git
      *
      * @return bool
      */
-    public function init($dir, $mustRun = false)
+    public function init($dir, $initial_branch='master', $mustRun = false)
     {
         if (is_dir($dir . '/.git')) {
             throw new \InvalidArgumentException("Already a repository: $dir");
         }
 
-        return (bool) $this->execute(['init'], $dir, $mustRun, false);
+        $args = ['init'];
+        if ($this->supportsGitInitialBranchFlag()) {
+            $args[] = "--initial-branch=$initial_branch";
+        }
+        return (bool) $this->execute($args, $dir, $mustRun, false);
     }
 
     /**
@@ -383,6 +387,14 @@ class Git
     public function supportsGitSshCommand()
     {
         return version_compare($this->getVersion(), '2.3', '>=');
+    }
+
+    /**
+     * @return bool
+     */
+    public function supportsGitInitialBranchFlag()
+    {
+        return version_compare($this->getVersion(), '2.28', '>=');
     }
 
     /**

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -151,7 +151,7 @@ class Git
      *
      * @return bool
      */
-    public function init($dir, $initial_branch='master', $mustRun = false)
+    public function init($dir, $initial_branch = '', $mustRun = false)
     {
         if (is_dir($dir . '/.git')) {
             throw new \InvalidArgumentException("Already a repository: $dir");

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -158,7 +158,7 @@ class Git
         }
 
         $args = ['init'];
-        if ($this->supportsGitInitialBranchFlag()) {
+        if ($initial_branch !== '' && $this->supportsGitInitialBranchFlag()) {
             $args[] = "--initial-branch=$initial_branch";
         }
         return (bool) $this->execute($args, $dir, $mustRun, false);


### PR DESCRIPTION
Changing 'master' to project->default_branch so we don't mention master if they specified something else.

Also, attempt to move to the correct branch after the init.