### PR TITLE
Use CA bundle detection everywhere else

### DIFF
--- a/src/CredentialHelper/Manager.php
+++ b/src/CredentialHelper/Manager.php
@@ -171,7 +171,7 @@ class Manager {
         }
 
         // Download from the URL.
-        $contents = file_get_contents($helper['url']);
+        $contents = file_get_contents($helper['url'], false, \stream_context_create($this->config->getStreamContextOptions(60)));
         if (!$contents) {
             throw new \RuntimeException('Failed to download credentials helper from URL: ' . $helper['url']);
         }

--- a/src/Service/SelfUpdater.php
+++ b/src/Service/SelfUpdater.php
@@ -119,6 +119,7 @@ class SelfUpdater
         $updater = new Updater($localPhar, false);
         $strategy = new ManifestStrategy(ltrim($currentVersion, 'v'), $manifestUrl, $this->allowMajor, $this->allowUnstable);
         $strategy->setManifestTimeout($this->timeout);
+        $strategy->setStreamContextOptions($this->config->getStreamContextOptions());
         $updater->setStrategyObject($strategy);
 
         if (!$updater->hasUpdate()) {


### PR DESCRIPTION
3 places this was not being used:

1. the installer (needs a copied version of the function)
2. the credential helper download
3. the self-updater (manifest and phar download) (#986)