### PR TITLE
Improve environment:delete command

### DIFF
--- a/src/Command/Activity/ActivityGetCommand.php
+++ b/src/Command/Activity/ActivityGetCommand.php
@@ -2,6 +2,7 @@
 namespace Platformsh\Cli\Command\Activity;
 
 use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Console\ArrayArgument;
 use Platformsh\Cli\Service\ActivityLoader;
 use Platformsh\Cli\Service\ActivityMonitor;
 use Platformsh\Cli\Service\PropertyFormatter;
@@ -25,7 +26,7 @@ class ActivityGetCommand extends CommandBase
             ->addArgument('id', InputArgument::OPTIONAL, 'The activity ID. Defaults to the most recent activity.')
             ->addOption('property', 'P', InputOption::VALUE_REQUIRED, 'The property to view')
             ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter by type (when selecting a default activity)')
-            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter by state (when selecting a default activity): in_progress, pending, complete, or cancelled')
+            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter by state (when selecting a default activity): in_progress, pending, complete, or cancelled.' . "\n" . ArrayArgument::SPLIT_HELP)
             ->addOption('result', null, InputOption::VALUE_REQUIRED, 'Filter by result (when selecting a default activity): success or failure')
             ->addOption('incomplete', 'i', InputOption::VALUE_NONE,
                 'Include only incomplete activities (when selecting a default activity).'

--- a/src/Command/Activity/ActivityListCommand.php
+++ b/src/Command/Activity/ActivityListCommand.php
@@ -3,6 +3,7 @@ namespace Platformsh\Cli\Command\Activity;
 
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
+use Platformsh\Cli\Console\ArrayArgument;
 use Platformsh\Cli\Service\ActivityMonitor;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
@@ -30,7 +31,7 @@ class ActivityListCommand extends CommandBase
 
         $this->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of results displayed', 10)
             ->addOption('start', null, InputOption::VALUE_REQUIRED, 'Only activities created before this date will be listed')
-            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter activities by state: in_progress, pending, complete, or cancelled')
+            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter activities by state: in_progress, pending, complete, or cancelled.' . "\n" . ArrayArgument::SPLIT_HELP)
             ->addOption('result', null, InputOption::VALUE_REQUIRED, 'Filter activities by result: success or failure')
             ->addOption('incomplete', 'i', InputOption::VALUE_NONE, 'Only list incomplete activities')
             ->addOption('all', 'a', InputOption::VALUE_NONE, 'List activities on all environments')

--- a/src/Command/Activity/ActivityLogCommand.php
+++ b/src/Command/Activity/ActivityLogCommand.php
@@ -2,6 +2,7 @@
 namespace Platformsh\Cli\Command\Activity;
 
 use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Console\ArrayArgument;
 use Platformsh\Cli\Service\ActivityMonitor;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Client\Model\Activity;
@@ -30,7 +31,7 @@ class ActivityLogCommand extends CommandBase
             )
             ->addOption('timestamps', 't', InputOption::VALUE_NONE, 'Display a timestamp next to each message')
             ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter by type (when selecting a default activity)')
-            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter by state (when selecting a default activity): in_progress, pending, complete, or cancelled')
+            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter by state (when selecting a default activity): in_progress, pending, complete, or cancelled.' . "\n" . ArrayArgument::SPLIT_HELP)
             ->addOption('result', null, InputOption::VALUE_REQUIRED, 'Filter by result (when selecting a default activity): success or failure')
             ->addOption('incomplete', 'i', InputOption::VALUE_NONE,
                 'Include only incomplete activities (when selecting a default activity).'

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -3,6 +3,7 @@
 namespace Platformsh\Cli\Command;
 
 use GuzzleHttp\Exception\BadResponseException;
+use Platformsh\Cli\Console\ArrayArgument;
 use Platformsh\Cli\Event\EnvironmentsChangedEvent;
 use Platformsh\Cli\Exception\LoginRequiredException;
 use Platformsh\Cli\Exception\NoOrganizationsException;
@@ -1304,8 +1305,11 @@ abstract class CommandBase extends Command implements MultiAwareInterface
                 );
             }
             $argument = $input->getArgument($this->envArgName);
-            if (is_array($argument) && count($argument) == 1) {
-                $argument = $argument[0];
+            if (is_array($argument)) {
+                $argument = ArrayArgument::split($argument);
+                if (count($argument) === 1) {
+                    $argument = $argument[0];
+                }
             }
             if (!is_array($argument)) {
                 $this->debug('Selecting environment based on input argument');

--- a/src/Command/Environment/EnvironmentDeleteCommand.php
+++ b/src/Command/Environment/EnvironmentDeleteCommand.php
@@ -2,6 +2,7 @@
 namespace Platformsh\Cli\Command\Environment;
 
 use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Console\ArrayArgument;
 use Platformsh\Client\Model\Environment;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,14 +16,16 @@ class EnvironmentDeleteCommand extends CommandBase
     {
         $this
             ->setName('environment:delete')
-            ->setAliases(['environment:deactivate'])
+            ->setHiddenAliases(['environment:deactivate'])
             ->setDescription('Delete an environment')
-            ->addArgument('environment', InputArgument::IS_ARRAY, 'The environment(s) to delete')
-            ->addOption('delete-branch', null, InputOption::VALUE_NONE, 'Delete the remote Git branch(es) too')
+            ->addArgument('environment', InputArgument::IS_ARRAY, "The environment(s) to delete.\nThe % character may be used as a wildcard." . "\n" . ArrayArgument::SPLIT_HELP)
+            ->addOption('delete-branch', null, InputOption::VALUE_NONE, 'Delete the remote Git branch(es)')
             ->addOption('no-delete-branch', null, InputOption::VALUE_NONE, 'Do not delete the remote Git branch(es)')
             ->addOption('inactive', null, InputOption::VALUE_NONE, 'Delete all inactive environments')
             ->addOption('merged', null, InputOption::VALUE_NONE, 'Delete all merged environments')
-            ->addOption('exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Environments not to delete');
+            ->addOption('type', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Environment type(s) of which to delete' . "\n" . ArrayArgument::SPLIT_HELP)
+            ->addOption('exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, "Environment(s) not to delete.\nThe % character may be used as a wildcard.\n" . ArrayArgument::SPLIT_HELP)
+            ->addOption('exclude-type', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Environment type(s) of which not to delete' . "\n" . ArrayArgument::SPLIT_HELP);
         $this->addProjectOption()
              ->addEnvironmentOption()
              ->addWaitOptions();
@@ -46,10 +49,36 @@ EOF
 
         $environments = $this->api()->getEnvironments($this->getSelectedProject());
 
-        $toDelete = [];
+        /** @var Environment[] $selectedEnvironments */
+        $selectedEnvironments = [];
+        $anythingSpecified = false;
+
+        // Add the environment(s) specified in the arguments or options.
+        $specifiedEnvironmentIds = ArrayArgument::getArgument($input, 'environment');
+        if ($input->getOption('environment')) {
+            $specifiedEnvironmentIds = array_merge([$input->getOption('environment')], $specifiedEnvironmentIds);
+        }
+        if ($specifiedEnvironmentIds) {
+            $anythingSpecified = true;
+            $specifiedEnvironmentIds = $this->findEnvironmentIDsByWildcards($environments, $specifiedEnvironmentIds);
+            $notFound = array_diff($specifiedEnvironmentIds, array_keys($environments));
+            if (!empty($notFound)) {
+                // Refresh the environments list if any environment is not found.
+                $environments = $this->api()->getEnvironments($this->getSelectedProject(), true);
+                $notFound = array_diff($specifiedEnvironmentIds, array_keys($environments));
+            }
+            foreach ($notFound as $notFoundId) {
+                $this->stdErr->writeln("Environment not found: <error>$notFoundId</error>");
+            }
+            $specifiedEnvironments = array_intersect_key($environments, array_flip($specifiedEnvironmentIds));
+            $this->stdErr->writeln(count($specifiedEnvironments) . ' environment(s) found by ID.');
+            $this->stdErr->writeln('');
+            $selectedEnvironments = array_merge($selectedEnvironments, $specifiedEnvironments);
+        }
 
         // Gather inactive environments.
         if ($input->getOption('inactive')) {
+            $anythingSpecified = true;
             if ($input->getOption('no-delete-branch')) {
                 $this->stdErr->writeln('The option --no-delete-branch cannot be combined with --inactive.');
 
@@ -62,15 +91,14 @@ EOF
                     return $environment->status == 'inactive';
                 }
             );
-            if (!$inactive) {
-                $this->stdErr->writeln('No inactive environments found.');
-            }
-            $toDelete = array_merge($toDelete, $inactive);
+            $this->stdErr->writeln(count($inactive) . ' inactive environment(s) found.');
+            $this->stdErr->writeln('');
+            $selectedEnvironments = array_merge($selectedEnvironments, $inactive);
         }
 
         // Gather merged environments.
         if ($input->getOption('merged')) {
-            $this->stdErr->writeln('Finding environments merged with their parent');
+            $anythingSpecified = true;
             $merged = [];
             foreach ($environments as $environment) {
                 $merge_info = $environment->getProperty('merge_info', false) ?: [];
@@ -78,79 +106,90 @@ EOF
                     $merged[$environment->id] = $environment;
                 }
             }
-            if (!$merged) {
-                $this->stdErr->writeln('No merged environments found.');
-            }
-            $toDelete = array_merge($toDelete, $merged);
+            $this->stdErr->writeln(count($merged) . ' merged environment(s) found.');
+            $this->stdErr->writeln('');
+            $selectedEnvironments = array_merge($selectedEnvironments, $merged);
         }
 
-        // If --merged and --inactive are not specified, look for the selected
-        // environment(s).
-        if (!$input->getOption('merged') && !$input->getOption('inactive')) {
-            if ($this->hasSelectedEnvironment()) {
-                $toDelete = [$this->getSelectedEnvironment()];
-            } elseif ($environmentIds = $input->getArgument('environment')) {
-                $notFound = array_diff($environmentIds, array_keys($environments));
-                if (!empty($notFound)) {
-                    // Refresh the environments list if any environment is not found.
-                    $environments = $this->api()->getEnvironments($this->getSelectedProject(), true);
-                    $notFound = array_diff($environmentIds, array_keys($environments));
+        // Gather environments with the specified --type (can be multiple).
+        if ($types = ArrayArgument::getOption($input, 'type')) {
+            $anythingSpecified = true;
+            $withTypes = [];
+            foreach ($environments as $environment) {
+                if ($environment->hasProperty('type') && \in_array($environment->getProperty('type'), $types)) {
+                    $withTypes[$environment->id] = $environment;
                 }
-                foreach ($notFound as $notFoundId) {
-                    $this->stdErr->writeln("Environment not found: <error>$notFoundId</error>");
-                }
-                $toDelete = array_intersect_key($environments, array_flip($environmentIds));
+            }
+            $this->stdErr->writeln(count($withTypes) . ' environment(s) found matching type(s): ' . implode(', ', $types));
+            $this->stdErr->writeln('');
+            $selectedEnvironments = array_merge($selectedEnvironments, $withTypes);
+        }
+
+        // Use the current environment (if it's not production).
+        if ($current = $this->getCurrentEnvironment($this->getSelectedProject())) {
+            if ($current->getProperty('type', false, false) !== 'production') {
+                $selectedEnvironments = \array_merge($selectedEnvironments, [$current]);
             }
         }
 
-        // Exclude environment(s) specified in --exclude.
-        $toDelete = array_diff_key($toDelete, array_flip($input->getOption('exclude')));
+        // Exclude environment type(s) specified in --exclude-type.
+        $excludeTypes = ArrayArgument::getOption($input, 'exclude-type');
+        $filtered = \array_filter($selectedEnvironments, function (Environment $environment) use ($excludeTypes) {
+            return !($environment->hasProperty('type', false) && \in_array($environment->getProperty('type', true, false), $excludeTypes, true));
+        });
+        if (($numExcluded = count($selectedEnvironments) - count($filtered)) > 0) {
+            $this->stdErr->writeln($numExcluded . ' environment(s) excluded by type.');
+            $this->stdErr->writeln('');
+        }
+        $selectedEnvironments = $filtered;
 
-        if (empty($toDelete)) {
-            $this->stdErr->writeln('No environment(s) to delete.');
-            $this->stdErr->writeln('Use --environment (-e) to specify an environment.');
-
-            return 1;
+        // Exclude environment ID(s) specified in --exclude.
+        $excludeIds = ArrayArgument::getOption($input, 'exclude');
+        if (!empty($excludeIds)) {
+            $resolved = $this->findEnvironmentIdsByWildcards($selectedEnvironments, $excludeIds);
+            if (count($resolved)) {
+                $selectedEnvironments = \array_filter($selectedEnvironments, function (Environment $e) use ($resolved) {
+                    return !\in_array($e->id, $resolved, true);
+                });
+                $this->stdErr->writeln(count($resolved) . ' environment(s) excluded by ID.');
+                $this->stdErr->writeln('');
+            }
         }
 
-        $success = $this->deleteMultiple($toDelete, $input, $this->stdErr);
+        if (count($selectedEnvironments)) {
+            $this->stdErr->writeln('Selected environment(s): <comment>' . implode('</comment>, <comment>', \array_map(function(Environment $e) { return $e->id; }, $selectedEnvironments)) . '</comment>');
+            $this->stdErr->writeln('');
+        }
 
-        return $success ? 0 : 1;
-    }
-
-    /**
-     * @param Environment[]   $environments
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return bool
-     */
-    protected function deleteMultiple(array $environments, InputInterface $input, OutputInterface $output)
-    {
-        // Confirm which environments the user wishes to be deleted.
-        $delete = [];
-        $deactivate = [];
+        // Confirm which of the environments the user wishes to be deleted.
+        $this->api()->sortResources($selectedEnvironments, 'id');
+        $toDeleteBranch = [];
+        $toDeactivate = [];
         $error = false;
         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
         $questionHelper = $this->getService('question_helper');
-        foreach ($environments as $environment) {
+        foreach ($selectedEnvironments as $environment) {
             $environmentId = $environment->id;
             // Check that the environment does not have children.
             // @todo remove this check when Platform's behavior is fixed
-            foreach ($this->api()->getEnvironments($this->getSelectedProject()) as $potentialChild) {
-                if ($potentialChild->parent == $environment->id) {
-                    $output->writeln(
-                        "The environment <error>$environmentId</error> has children and therefore can't be deleted."
-                    );
-                    $output->writeln("Please delete the environment's children first.");
+            foreach ($environments as $potentialChild) {
+                if ($potentialChild->parent === $environment->id) {
+                    $this->stdErr->writeln(\sprintf(
+                        "The environment %s has children and therefore can't be deleted.",
+                        $this->api()->getEnvironmentLabel($environment, 'error')
+                    ));
+                    $this->stdErr->writeln("Please delete the environment's children first.");
                     $error = true;
                     continue 2;
                 }
             }
             if ($environment->isActive()) {
-                $output->writeln("The environment <comment>$environmentId</comment> is currently active: deleting it will delete all associated data.");
-                if ($questionHelper->confirm("Are you sure you want to delete the environment <comment>$environmentId</comment>?")) {
-                    $deactivate[$environmentId] = $environment;
+                $this->stdErr->writeln(\sprintf(
+                    'The environment %s is currently active: deleting it will delete all associated data.',
+                    $this->api()->getEnvironmentLabel($environment, 'comment')
+                ));
+                if ($questionHelper->confirm('Are you sure you want to delete this environment?')) {
+                    $toDeactivate[$environmentId] = $environment;
                     if (!$input->getOption('no-delete-branch')
                         && $this->shouldWait($input)
                         && ($input->getOption('delete-branch')
@@ -159,30 +198,81 @@ EOF
                                 && $questionHelper->confirm("Delete the remote Git branch too?")
                             )
                         )) {
-                        $delete[$environmentId] = $environment;
+                        $toDeleteBranch[$environmentId] = $environment;
                     }
+                } else {
+                    $error = true;
                 }
             } elseif ($environment->status === 'inactive') {
                 if ($questionHelper->confirm("Are you sure you want to delete the remote Git branch <comment>$environmentId</comment>?")) {
-                    $delete[$environmentId] = $environment;
+                    $toDeleteBranch[$environmentId] = $environment;
+                } else {
+                    $error = true;
                 }
             } elseif ($environment->status === 'dirty') {
-                $output->writeln("The environment <error>$environmentId</error> is currently building, and therefore can't be deleted. Please wait.");
+                $this->stdErr->writeln("The environment <error>$environmentId</error> is currently building, and therefore can't be deleted. Please wait.");
                 $error = true;
-                continue;
+            } elseif ($environment->status === 'deleting') {
+                $this->stdErr->writeln("The environment <info>$environmentId</info> is already being deleted.");
+            } else {
+                $this->stdErr->writeln("The environment <error>$environmentId</error> has an unrecognised status <error>" . $environment->status . "</error>.");
+                $error = true;
             }
         }
 
+        if (empty($toDeleteBranch) && empty($toDeactivate)) {
+            if ($error) {
+                $this->stdErr->writeln('');
+            }
+            $this->stdErr->writeln('No environment(s) to delete.');
+
+            return $error || $anythingSpecified ? 1 : 0;
+        }
+
+        $success = $this->deleteMultiple($toDeactivate, $toDeleteBranch, $input) && !$error;
+
+        return $success ? 0 : 1;
+    }
+
+    /**
+     * Finds environments in a list matching a list of ID wildcards.
+     *
+     * @param Environment[] $environments
+     * @param string[] $wildcards
+     *
+     * @return string[]
+     */
+    private function findEnvironmentIDsByWildcards(array $environments, $wildcards)
+    {
+        $ids = \array_map(function (Environment $e) { return $e->id; }, $environments);
+        $found = [];
+        foreach ($wildcards as $wildcard) {
+            $pattern = '/^' . str_replace('%', '.*', preg_quote($wildcard)) . '$/';
+            $found = array_merge($found, \preg_grep($pattern, $ids));
+        }
+        return \array_unique($found);
+    }
+
+    /**
+     * @param array $toDeactivate
+     * @param array $toDeleteBranch
+     * @param InputInterface $input
+     *
+     * @return bool
+     */
+    protected function deleteMultiple(array $toDeactivate, array $toDeleteBranch, InputInterface $input)
+    {
+        $error = false;
         $deactivateActivities = [];
         $deactivated = 0;
         /** @var Environment $environment */
-        foreach ($deactivate as $environmentId => $environment) {
+        foreach ($toDeactivate as $environmentId => $environment) {
             try {
-                $output->writeln("Deleting environment <info>$environmentId</info>");
+                $this->stdErr->writeln("Deleting environment <info>$environmentId</info>");
                 $deactivateActivities[] = $environment->deactivate();
                 $deactivated++;
             } catch (\Exception $e) {
-                $output->writeln($e->getMessage());
+                $this->stdErr->writeln($e->getMessage());
             }
         }
 
@@ -195,28 +285,28 @@ EOF
         }
 
         $deleted = 0;
-        foreach ($delete as $environmentId => $environment) {
+        foreach ($toDeleteBranch as $environmentId => $environment) {
             try {
                 if ($environment->status !== 'inactive') {
                     $environment->refresh();
                     if ($environment->status !== 'inactive') {
-                        $output->writeln("Cannot delete branch <error>$environmentId</error>: it is not (yet) inactive.");
+                        $this->stdErr->writeln("Cannot delete branch <error>$environmentId</error>: it is not (yet) inactive.");
                         continue;
                     }
                 }
                 $environment->delete();
-                $output->writeln("Deleted remote Git branch <info>$environmentId</info>");
+                $this->stdErr->writeln("Deleted remote Git branch <info>$environmentId</info>");
                 $deleted++;
             } catch (\Exception $e) {
-                $output->writeln($e->getMessage());
+                $this->stdErr->writeln($e->getMessage());
             }
         }
 
         if ($deleted > 0) {
-            $output->writeln("Run <info>git fetch --prune</info> to remove deleted branches from your local cache.");
+            $this->stdErr->writeln("Run <info>git fetch --prune</info> to remove deleted branches from your local cache.");
         }
 
-        if ($deleted < count($delete) || $deactivated < count($deactivate)) {
+        if ($deleted < count($toDeleteBranch) || $deactivated < count($toDeactivate)) {
             $error = true;
         }
 

--- a/src/Command/Integration/Activity/IntegrationActivityListCommand.php
+++ b/src/Command/Integration/Activity/IntegrationActivityListCommand.php
@@ -4,6 +4,7 @@ namespace Platformsh\Cli\Command\Integration\Activity;
 
 use Platformsh\Cli\Command\Integration\IntegrationCommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
+use Platformsh\Cli\Console\ArrayArgument;
 use Platformsh\Cli\Service\ActivityMonitor;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
@@ -26,7 +27,7 @@ class IntegrationActivityListCommand extends IntegrationCommandBase
             ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter activities by type')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of results displayed', 10)
             ->addOption('start', null, InputOption::VALUE_REQUIRED, 'Only activities created before this date will be listed')
-            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter activities by state')
+            ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter activities by state.' . "\n" . ArrayArgument::SPLIT_HELP)
             ->addOption('result', null, InputOption::VALUE_REQUIRED, 'Filter activities by result')
             ->setDescription('Get a list of activities for an integration');
         $this->setHiddenAliases(['integration:activities']);

--- a/src/Console/ArrayArgument.php
+++ b/src/Console/ArrayArgument.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Platformsh\Cli\Console;
+
+class ArrayArgument
+{
+    const SPLIT_HELP = 'If a single value is specified, it will be split by commas or whitespace.';
+
+    /**
+     * Gets the value of an array input argument.
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param string $argName
+     *
+     * @return string[]
+     */
+    public static function getArgument(\Symfony\Component\Console\Input\InputInterface $input, $argName)
+    {
+        $value = $input->getArgument($argName);
+        if (!\is_array($value)) {
+            throw new \BadMethodCallException(\sprintf('The value of argument %s is not an array', $argName));
+        }
+        return self::split($value);
+    }
+
+    /**
+     * Gets the value of an array input option.
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param string $optionName
+     *
+     * @return string[]
+     */
+    public static function getOption(\Symfony\Component\Console\Input\InputInterface $input, $optionName)
+    {
+        $value = $input->getOption($optionName);
+        if (!\is_array($value)) {
+            throw new \BadMethodCallException(\sprintf('The value of option --%s is not an array', $optionName));
+        }
+        return self::split($value);
+    }
+
+    /**
+     * Splits the first value, by commas or whitespace, if there is only one.
+     *
+     * @param []string $args
+     *
+     * @return array
+     */
+    public static function split($args)
+    {
+        if (\count($args) !== 1) {
+            return $args;
+        }
+        return \array_filter(\preg_split('/[,\s]+/', \reset($args)), '\\strlen');
+    }
+}

--- a/src/Service/ActivityLoader.php
+++ b/src/Service/ActivityLoader.php
@@ -2,6 +2,7 @@
 
 namespace Platformsh\Cli\Service;
 
+use Platformsh\Cli\Console\ArrayArgument;
 use Platformsh\Client\Model\Activities\HasActivitiesInterface;
 use Platformsh\Client\Model\Activity;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -46,10 +47,7 @@ class ActivityLoader
     public function loadFromInput(HasActivitiesInterface $apiResource, InputInterface $input, $limit = null, $state = [], $withOperation = '')
     {
         if ($state === [] && $input->hasOption('state')) {
-            $state = $input->getOption('state');
-            if (\count($state) === 1) {
-                $state = \array_filter(\preg_split('/[,\s]+/', \reset($state)), '\\strlen');
-            }
+            $state = ArrayArgument::getOption($input, 'state');
             if ($input->getOption('incomplete')) {
                 if ($state && $state != [Activity::STATE_IN_PROGRESS, Activity::STATE_PENDING]) {
                     $this->stdErr->writeln('The <comment>--incomplete</comment> option implies <comment>--state in_progress,pending</comment>');


### PR DESCRIPTION
* Add --type and --exclude-type options
* Include the environment(s) specified by ID, even when --inactive or --merged are also specified
* Split the environment value by commas, in the 'environment' argument (when a single value is given)
* Make the reason for environments being found clearer
* Handle all environment statuses