### PR TITLE
Use the newer backups API - for listing only

### DIFF
--- a/src/Command/Backup/BackupListCommand.php
+++ b/src/Command/Backup/BackupListCommand.php
@@ -3,7 +3,6 @@ namespace Platformsh\Cli\Command\Backup;
 
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
-use Platformsh\Cli\Service\ActivityMonitor;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,52 +18,62 @@ class BackupListCommand extends CommandBase
             ->setName('backup:list')
             ->setAliases(['backups'])
             ->setDescription('List available backups of an environment')
-            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of backups to list', 10)
-            ->addOption('start', null, InputOption::VALUE_REQUIRED, 'Only backups created before this date will be listed');
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, '[Deprecated] - this option is unused')
+            ->addOption('start', null, InputOption::VALUE_REQUIRED, '[Deprecated] - this option is unused');
         Table::configureInput($this->getDefinition());
         PropertyFormatter::configureInput($this->getDefinition());
         $this->addProjectOption()
              ->addEnvironmentOption();
         $this->setHiddenAliases(['snapshots', 'snapshot:list']);
-        $this->addExample('List the most recent backups')
-             ->addExample('List backups made before last week', "--start '1 week ago'");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->warnAboutDeprecatedOptions(['start']);
         $this->validateInput($input);
 
         $environment = $this->getSelectedEnvironment();
-
-        $startsAt = null;
-        if ($input->getOption('start') && !($startsAt = strtotime($input->getOption('start')))) {
-            $this->stdErr->writeln('Invalid date: <error>' . $input->getOption('start') . '</error>');
-            return 1;
-        }
 
         /** @var \Platformsh\Cli\Service\Table $table */
         $table = $this->getService('table');
         /** @var \Platformsh\Cli\Service\PropertyFormatter $formatter */
         $formatter = $this->getService('property_formatter');
 
-        /** @var \Platformsh\Cli\Service\ActivityLoader $loader */
-        $loader = $this->getService('activity_loader');
-        $activities = $loader->load($environment, $input->getOption('limit'), 'environment.backup', $startsAt, 'complete');
-        if (!$activities) {
+        $backups = $environment->getBackups($input->getOption('limit'));
+        if (!$backups) {
             $this->stdErr->writeln('No backups found');
             return 1;
         }
 
-        $headers = ['Created', 'name' => 'Backup name', 'Progress', 'State', 'Result'];
+        $table->replaceDeprecatedColumns(['created' => 'created_at', 'name' => 'id'], $input, $output);
+        $table->removeDeprecatedColumns(['progress', 'state', 'result'], '[deprecated]', $input, $output);
+
+        $headers = [
+            'created_at' => 'Created',
+            'expires_at' => 'Expires',
+            'id' => 'Backup ID',
+            'status' => 'Status',
+            'commit_id' => 'Commit ID',
+            'safe' => 'Safe',
+            'restorable' => 'Restorable',
+            'index' => 'Index',
+            '[deprecated]' => '[Deprecated]',
+        ];
+        $defaultColumns = ['created_at', 'id', 'restorable'];
         $rows = [];
-        foreach ($activities as $activity) {
-            $backup_name = !empty($activity->payload['backup_name']) ? $activity->payload['backup_name'] : 'N/A';
+        foreach ($backups as $backup) {
             $rows[] = [
-                $formatter->format($activity->created_at, 'created_at'),
-                'name' => new AdaptiveTableCell($backup_name, ['wrap' => false]),
-                $activity->getCompletionPercent() . '%',
-                ActivityMonitor::formatState($activity->state),
-                ActivityMonitor::formatResult($activity->result, !$table->formatIsMachineReadable()),
+                'created_at' => $formatter->format($backup->created_at, 'created_at'),
+                'updated_at' => $formatter->format($backup->updated_at, 'updated_at'),
+                'expires_at' => $formatter->format($backup->expires_at, 'expires_at'),
+                'id' => new AdaptiveTableCell($backup->id, ['wrap' => false]),
+                'name' => $backup->id,
+                'commit_id' => $backup->commit_id,
+                'safe' => $formatter->format($backup->safe),
+                'restorable' => $formatter->format($backup->restorable),
+                'index' => $backup->index,
+                'status' => $backup->status,
+                '[deprecated]' => '',
             ];
         }
 
@@ -76,20 +85,7 @@ class BackupListCommand extends CommandBase
             ));
         }
 
-        $table->render($rows, $headers);
-
-        $max = $input->getOption('limit') ? (int) $input->getOption('limit') : 10;
-        $maybeMoreAvailable = count($activities) === $max;
-        if (!$table->formatIsMachineReadable() && $maybeMoreAvailable) {
-            $this->stdErr->writeln('');
-            $this->stdErr->writeln(sprintf(
-                'More backups may be available.'
-                . ' To display older backups, increase <info>--limit</info> above %d, or set <info>--start</info> to a date in the past.'
-                . ' For more information, run: <info>%s backups -h</info>',
-                $max,
-                $this->config()->get('application.executable')
-            ));
-        }
+        $table->render($rows, $headers, $defaultColumns);
 
         return 0;
     }


### PR DESCRIPTION
A partial version of https://github.com/platformsh/platformsh-cli/pull/1089

and the API seems only to list restorable backups, so that may help with #1114 without needing to add another option

The `backup:restore` command would still be activity-based (i.e. it couldn't filter by restorable backups); this MR only changes the `backup:list` (`backups`) command.