### PR TITLE
Fix a bug when listing the activities created at the same second

### DIFF
--- a/src/Service/ActivityLoader.php
+++ b/src/Service/ActivityLoader.php
@@ -2,6 +2,7 @@
 
 namespace Platformsh\Cli\Service;
 
+use DateTime;
 use Platformsh\Client\Model\Activities\HasActivitiesInterface;
 use Platformsh\Client\Model\Activity;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -63,7 +64,7 @@ class ActivityLoader
         $type = $input->hasOption('type') ? $input->getOption('type') : null;
         $result = $input->hasOption('result') ? $input->getOption('result') : null;
         $startsAt = null;
-        if ($input->hasOption('start') && $input->getOption('start') && !($startsAt = strtotime($input->getOption('start')))) {
+        if ($input->hasOption('start') && $input->getOption('start') && !($startsAt = new DateTime($input->getOption('start')))) {
             $this->stdErr->writeln('Invalid --start date: <error>' . $input->getOption('start') . '</error>');
             return [];
         }
@@ -109,7 +110,7 @@ class ActivityLoader
 
         while ($limit === null || count($activities) < $limit) {
             if ($activity = end($activities)) {
-                $startsAt = strtotime($activity->created_at);
+                $startsAt = new DateTime($activity->created_at);
             }
             $nextActivities = $apiResource->getActivities($limit ? $limit - count($activities) : 0, $type, $startsAt, $state, $result);
             $new = false;


### PR DESCRIPTION
There is a bug when listing activities that have been created as the same second (same UNIX timestamp in seconds). 

## Problem

Let's take a project where 6 CRONs are scheduled at the same time.

If I directly request the API, I'll receive something like this: 
| ID            | Created                                  | Description |
| -----------  | -------------------------------------- | --------------- |
| aaaaaa   | 2022-01-01T00:00:00.000000+00:00  | CRON1      |
| bbbbbb   | 2022-01-01T00:00:00.111111+00:00  | CRON2      |
| cccccc   | 2022-01-01T00:00:00.222222+00:00  | CRON3     |
| dddddd   | 2022-01-01T00:00:00.333333+00:00  | CRON4     |
| eeeeeee   | 2022-01-01T00:00:00.444444+00:00  | CRON5     |
| ffffff   | 2022-01-01T00:00:00.555555+00:00  | CRON6     |

As you can see here, the 6 executions have been created at the same time, with different microseconds. 

Let's test do some testing:
```
platform act:list -p zzzzzzzzzz -e production --limit 10 --start 2022-01-01T00:00:00+00:00
<no record>

platform act:list -p zzzzzzzzzz -e production --limit 10 --start 2022-01-01T00:00:00.666666+00:00
<no record>
```

As you can see here the microseconds are not supported in the start parameter, otherwise the second command will have returned our activities.
What happens is that `2022-01-01T00:00:00.666666+00:00` is truncated to `2022-01-01T00:00:00+00:00` when passed to the `$apiResource->getActivities` method, as it requires a "UNIX timestamp in seconds" as parameters. 
So in our case the command 1 and command 2 are equivalent. 

## Hidden problem 

This problem also affects the pagination process. 

Today the Platform.sh API only supports listing the activities by batch of 10. In order to request more at once, the CLI is taking the `created_at` date of the last record, and send it as the next `--start` value. 
If you combine this to the problem identified previously, it may hide some records as it will truncate its microseconds. 

## Solution 

In this solution, I propose to support DateTime in the `$apiResource->getActivities` methods, which will support microseconds. 

The solution is (based on my testing) backward compatible with the current implementation, as `new DateTime(string)` seems to be as flexible as `strtotime`. 
For instance using partial ISO dates still works: 

```
new DateTime("2022-02-22T02:20Z").format('Y-m-d\TH:i:s.uP') === "2022-02-22T02:20:00.000000+00:00"
```

⚠️ This PR needs to have the [related changes in the php-client to support DateTime](https://github.com/platformsh/platformsh-client-php/pull/69) merged and published first. 