### PR TITLE
Add --if-exists to pgsql dump so it can be used on empty database

### DIFF
--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -192,7 +192,7 @@ class DbDumpCommand extends CommandBase
 
         switch ($database['scheme']) {
             case 'pgsql':
-                $dumpCommand = 'pg_dump --no-owner --clean --blobs ' . $relationships->getDbCommandArgs('pg_dump', $database, $schema);
+                $dumpCommand = 'pg_dump --no-owner --if-exists --clean --blobs ' . $relationships->getDbCommandArgs('pg_dump', $database, $schema);
                 if ($schemaOnly) {
                     $dumpCommand .= ' --schema-only';
                 }


### PR DESCRIPTION
* https://github.com/drud/ddev/issues/3867

If pgsql is used without `--if-exists` then the resultant dumpfile has (very early, before anything else) stanzas like:

```
DROP INDEX public.watchdog__uid__idx;
DROP INDEX public.watchdog__type__idx;
DROP INDEX public.watchdog__severity__idx;
DROP INDEX public.users_field_data__user_field__mail__idx;
```

Unfortunately, when trying to import to an empty database these all fail because the indexes don't exist. 

However, if the dump is created with `--if-exists` then the correct DROP (and related) statements are created:

```
DROP INDEX IF EXISTS public.watchdog__uid__idx;
DROP INDEX IF EXISTS public.watchdog__type__idx;
DROP INDEX IF EXISTS public.watchdog__severity__idx;
DROP INDEX IF EXISTS public.users_field_data__user_field__mail__idx;
DROP INDEX IF EXISTS public.users_field_data__user_field__created__idx;
```

I have no idea why `--if-exists` is not the default behavior, but it seems not to be. 

I believe this behavior should work everywhere, disrupt nothing, and should also be used in PSH backups.