### PR TITLE
Translate environment ID to type when adding/changing a user

### DIFF
--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -298,7 +298,7 @@ class EnvironmentPushCommand extends CommandBase
      */
     private function askEnvironmentType(Project $project) {
         try {
-            $types = $project->getEnvironmentTypes();
+            $types = $this->api()->getEnvironmentTypes($project);
         } catch (BadResponseException $e) {
             if ($e->getResponse() && $e->getResponse()->getStatusCode() === 404) {
                 $this->debug('Cannot list environment types. The project probably does not yet support them.');

--- a/src/Command/User/UserAddCommand.php
+++ b/src/Command/User/UserAddCommand.php
@@ -79,7 +79,7 @@ class UserAddCommand extends CommandBase
 
         $hasOutput = false;
 
-        $environmentTypes = $project->getEnvironmentTypes();
+        $environmentTypes = $this->api()->getEnvironmentTypes($project);
 
         // Process the --role option.
         $roleInput = ArrayArgument::getOption($input, 'role');
@@ -122,7 +122,8 @@ class UserAddCommand extends CommandBase
             }
             $this->stdErr->writeln('');
             // Convert the list of environment-based roles to type-based roles.
-            $environments = $this->api()->getEnvironments($project);
+            // Refresh the environments to check their types more accurately.
+            $environments = $this->api()->getEnvironments($project, true);
             $converted = $this->convertEnvironmentRolesToTypeRoles($specifiedEnvironmentRoles, $specifiedTypeRoles, $environments, $this->stdErr);
             if ($converted === false) {
                 return 1;

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -1318,26 +1318,6 @@ class Api
     }
 
     /**
-     * Checks if a project supports environment types.
-     *
-     * @todo remove this when environment types are supported everywhere
-     *
-     * @param Project $project
-     *
-     * @return bool
-     */
-    public function supportsEnvironmentTypes(Project $project)
-    {
-        if ($project->operationAvailable('environment-types')) {
-            return true;
-        }
-        foreach ($this->getEnvironments($project) as $env) {
-            return $env->hasProperty('type', false);
-        }
-        return false;
-    }
-
-    /**
      * Loads a subscription through various APIs to see which one wins.
      *
      * @param string $id

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -646,7 +646,7 @@ class Api
      * @param bool|null $refresh Whether to refresh the list.
      * @param bool      $events  Whether to update Drush aliases if the list changes.
      *
-     * @return Environment[] The user's environments, keyed by ID.
+     * @return array<string, Environment> The user's environments, keyed by ID.
      */
     public function getEnvironments(Project $project, $refresh = null, $events = true)
     {

--- a/tests/Command/User/UserAddCommandTest.php
+++ b/tests/Command/User/UserAddCommandTest.php
@@ -5,11 +5,15 @@ namespace Platformsh\Cli\Tests\Command\User;
 use GuzzleHttp\Client;
 use Platformsh\Cli\Command\User\UserAddCommand;
 use Platformsh\Client\Model\Environment;
+use Platformsh\Client\Model\EnvironmentType;
 use Symfony\Component\Console\Output\NullOutput;
 
 class UserAddCommandTest extends \PHPUnit_Framework_TestCase
 {
-    public function testConvertEnvironmentRolesToTypeRoles()
+    private $mockEnvironments = [];
+    private $mockTypes = [];
+
+    protected function setUp()
     {
         // Set up mock environments.
         $mockEnvironmentData = [
@@ -19,12 +23,111 @@ class UserAddCommandTest extends \PHPUnit_Framework_TestCase
             ['id' => 'dev2', 'type' => 'development'],
             ['id' => 'dev3', 'type' => 'development'],
         ];
-        $mockEnvironments = [];
+        $mockTypeData = [
+            ['id' => 'production'],
+            ['id' => 'staging'],
+            ['id' => 'development'],
+        ];
+        $this->mockEnvironments = [];
         $client = new Client();
         foreach ($mockEnvironmentData as $data) {
-            $mockEnvironments[$data['id']] = new Environment($data, 'http://127.0.0.1:10000/api/projects/foo/environments', $client, true);
+            $this->mockEnvironments[$data['id']] = new Environment($data, 'http://127.0.0.1:10000/api/projects/foo/environments', $client, true);
         }
+        foreach ($mockTypeData as $data) {
+            $this->mockTypes[$data['id']] = new EnvironmentType($data, 'http://127.0.0.1:10000/api/projects/foo/environment-types', $client, true);
+        }
+    }
 
+    public function testGetSpecifiedEnvironmentRoles()
+    {
+        // Set up a mock command to make the private method accessible.
+        $command = new UserAddCommand();
+        $m = new \ReflectionMethod($command, 'getSpecifiedEnvironmentRoles');
+        $m->setAccessible(true);
+
+        // Test cases: triples of environment role arguments, the output, and the error message if any.
+        // TODO convert to anonymous class in PHP 7
+        $cases = [
+            [
+                ['m%:v', 'stg:admin', 'dev1%:c'],
+                ['main' => 'viewer', 'stg' => 'admin', 'dev1' => 'contributor'],
+            ],
+            [
+                ['%tg:a', 'viewer'],
+                ['stg' => 'admin'],
+            ],
+            [
+                ['main:viewer', 'nonexistent:a'],
+                [],
+                'No environment IDs match: nonexistent',
+            ],
+            [
+                ['main:viewer', 'stg:invalid-role'],
+                [],
+                'Invalid role: invalid-role',
+            ],
+        ];
+        foreach ($cases as $i => $case) {
+            list($args, $expectedRoles) = $case;
+            $errorMessage = isset($case[2]) ? $case[2] : '';
+            try {
+                $result = $m->invoke($command, $args, $this->mockEnvironments);
+                $this->assertEquals($expectedRoles, $result, "case $i roles");
+                $this->assertEquals($errorMessage, '', "case $i error message");
+            } catch (\InvalidArgumentException $e) {
+                $this->assertEquals($errorMessage, $e->getMessage(), "case $i error message");
+            }
+        }
+    }
+
+    public function testGetSpecifiedTypeRoles()
+    {
+        // Set up a mock command to make the private method accessible.
+        $command = new UserAddCommand();
+        $m = new \ReflectionMethod($command, 'getSpecifiedTypeRoles');
+        $m->setAccessible(true);
+
+        // Test cases: quintuples of role arguments, the output, whether to ignore errors, the error message if any, the remaining roles if any.
+        // TODO convert to anonymous class in PHP 7
+        $cases = [
+            [
+                ['staging:viewer', 'stg:admin', 'viewer'],
+                ['staging' => 'viewer'],
+                true,
+                '',
+                ['stg:admin', 'viewer'],
+            ],
+            [
+                ['development:viewer', 'nonexistent:viewer', 'stg:admin'],
+                [],
+                false,
+                'No environment type IDs match: nonexistent',
+            ],
+            [
+                ['dev%:v', 'prod:admin'],
+                ['development' => 'viewer'],
+                true,
+                '',
+                ['prod:admin'],
+            ],
+        ];
+        foreach ($cases as $i => $case) {
+            list($roles, $expectedRoles, $ignoreErrors) = $case;
+            $expectedErrorMessage = isset($case[3]) ? $case[3] : '';
+            $expectedRemainingRoles = isset($case[4]) ? $case[4] : [];
+            try {
+                $result = $m->invokeArgs($command, [&$roles, $this->mockTypes, $ignoreErrors]);
+                $this->assertEquals($expectedRoles, $result, "case $i roles");
+                $this->assertEquals($expectedErrorMessage, '', "case $i error message");
+                $this->assertEquals($expectedRemainingRoles, array_values($roles), "case $i remaining roles");
+            } catch (\InvalidArgumentException $e) {
+                $this->assertEquals($expectedErrorMessage, $e->getMessage(), "case $i error message");
+            }
+        }
+    }
+
+    public function testConvertEnvironmentRolesToTypeRoles()
+    {
         // Set up a mock command to make the private method accessible.
         $command = new UserAddCommand();
         $m = new \ReflectionMethod($command, 'convertEnvironmentRolesToTypeRoles');
@@ -59,10 +162,10 @@ class UserAddCommandTest extends \PHPUnit_Framework_TestCase
             ],
         ];
         $output = new NullOutput();
-        foreach ($cases as $case) {
+        foreach ($cases as $i => $case) {
             list($environmentRoles, $typeRoles, $expectedTypeRoles) = $case;
-            $result = $m->invoke($command, $environmentRoles, $typeRoles, $mockEnvironments, $output);
-            $this->assertEquals($expectedTypeRoles, $result);
+            $result = $m->invoke($command, $environmentRoles, $typeRoles, $this->mockEnvironments, $output);
+            $this->assertEquals($expectedTypeRoles, $result, "case $i");
         }
     }
 }

--- a/tests/Command/User/UserAddCommandTest.php
+++ b/tests/Command/User/UserAddCommandTest.php
@@ -30,25 +30,38 @@ class UserAddCommandTest extends \PHPUnit_Framework_TestCase
         $m = new \ReflectionMethod($command, 'convertEnvironmentRolesToTypeRoles');
         $m->setAccessible(true);
 
-        // Test cases: pairs of input (environment roles) and output (type roles or false on error).
+        // Test cases: triples of environment roles, type roles, and output (converted type roles, or false on error).
         $cases = [
             [
                 ['stg' => 'viewer', 'dev1' => 'contributor'],
+                [],
                 ['staging' => 'viewer', 'development' => 'contributor'],
             ],
             [
                 ['main' => 'viewer', 'stg' => 'admin', 'dev2' => 'admin'],
+                [],
                 ['production' => 'viewer', 'staging' => 'admin', 'development' => 'admin'],
             ],
             [
                 ['stg' => 'viewer', 'dev1' => 'contributor', 'dev2' => 'viewer'],
+                [],
+                false,
+            ],
+            [
+                ['main' => 'viewer', 'stg' => 'admin', 'dev2' => 'admin'],
+                ['development' => 'admin'],
+                ['production' => 'viewer', 'staging' => 'admin', 'development' => 'admin'],
+            ],
+            [
+                ['main' => 'viewer', 'stg' => 'admin', 'dev2' => 'admin'],
+                ['development' => 'contributor'],
                 false,
             ],
         ];
         $output = new NullOutput();
         foreach ($cases as $case) {
-            list($environmentRoles, $expectedTypeRoles) = $case;
-            $result = $m->invoke($command, $environmentRoles, $mockEnvironments, $output);
+            list($environmentRoles, $typeRoles, $expectedTypeRoles) = $case;
+            $result = $m->invoke($command, $environmentRoles, $typeRoles, $mockEnvironments, $output);
             $this->assertEquals($expectedTypeRoles, $result);
         }
     }

--- a/tests/Command/User/UserAddCommandTest.php
+++ b/tests/Command/User/UserAddCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Platformsh\Cli\Tests\Command\User;
+
+use GuzzleHttp\Client;
+use Platformsh\Cli\Command\User\UserAddCommand;
+use Platformsh\Client\Model\Environment;
+use Symfony\Component\Console\Output\NullOutput;
+
+class UserAddCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConvertEnvironmentRolesToTypeRoles()
+    {
+        // Set up mock environments.
+        $mockEnvironmentData = [
+            ['id' => 'main', 'type' => 'production'],
+            ['id' => 'stg', 'type' => 'staging'],
+            ['id' => 'dev1', 'type' => 'development'],
+            ['id' => 'dev2', 'type' => 'development'],
+            ['id' => 'dev3', 'type' => 'development'],
+        ];
+        $mockEnvironments = [];
+        $client = new Client();
+        foreach ($mockEnvironmentData as $data) {
+            $mockEnvironments[$data['id']] = new Environment($data, 'http://127.0.0.1:10000/api/projects/foo/environments', $client, true);
+        }
+
+        // Set up a mock command to make the private method accessible.
+        $command = new UserAddCommand();
+        $m = new \ReflectionMethod($command, 'convertEnvironmentRolesToTypeRoles');
+        $m->setAccessible(true);
+
+        // Test cases: pairs of input (environment roles) and output (type roles or false on error).
+        $cases = [
+            [
+                ['stg' => 'viewer', 'dev1' => 'contributor'],
+                ['staging' => 'viewer', 'development' => 'contributor'],
+            ],
+            [
+                ['main' => 'viewer', 'stg' => 'admin', 'dev2' => 'admin'],
+                ['production' => 'viewer', 'staging' => 'admin', 'development' => 'admin'],
+            ],
+            [
+                ['stg' => 'viewer', 'dev1' => 'contributor', 'dev2' => 'viewer'],
+                false,
+            ],
+        ];
+        $output = new NullOutput();
+        foreach ($cases as $case) {
+            list($environmentRoles, $expectedTypeRoles) = $case;
+            $result = $m->invoke($command, $environmentRoles, $mockEnvironments, $output);
+            $this->assertEquals($expectedTypeRoles, $result);
+        }
+    }
+}


### PR DESCRIPTION
Currently, in non-interactive mode, the `user:add` and `user:update` commands support adding users to specific environments, if these are specified on the command line, whether or not the project supports environment types. This is to preserve backwards compatibility for those who are using this command in non-interactive scripts. The server will then silently apply these changes to the entire environment type(s).

This PR instead converts environment-specific access to environment type-based access on the "client side" (within the CLI), rather than the server side. As before, in interactive mode, it will return an error if such environment-specific access has been specified, but now it attempts to provide an example of how to use the command with environment types. In non-interactive mode, it continues as before, but now with warnings that describe how the roles will now be applied to the whole environment type, and it uses the API by environment type rather than by environment ID.

To summarise, this affects **only**:
* `user:add` or `user:update`
* in non-interactive mode (via PLATFORMSH_CLI_NO_INTERACTION or `--yes` or `-y`)
* specifying environment-specific roles on the command line, e.g. `--role main:viewer`

This changes the API call (moving work from server side to client side), but **the resulting user access will be the same**.

Additionally this PR removes support for projects which do not support environment types. No such projects now exist.