### PR TITLE
Rework fetching projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.29 <2.0",
-        "platformsh/client": ">=0.62.1 <2.0",
+        "platformsh/client": ">=0.64.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c3690b89903ea7cf71614631669490a",
+    "content-hash": "6ea4d9a5f1a732f4b6e4ac31c673bba0",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -731,16 +731,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.62.2",
+            "version": "0.64.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "2a445a6a9d303ebd3f8257e59005ba5257b3ef3f"
+                "reference": "e64d379f19fa96f261cdb5d42c062503ff8d1383"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/2a445a6a9d303ebd3f8257e59005ba5257b3ef3f",
-                "reference": "2a445a6a9d303ebd3f8257e59005ba5257b3ef3f",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/e64d379f19fa96f261cdb5d42c062503ff8d1383",
+                "reference": "e64d379f19fa96f261cdb5d42c062503ff8d1383",
                 "shasum": ""
             },
             "require": {
@@ -772,9 +772,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.62.2"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.64.0"
             },
-            "time": "2022-08-22T15:25:50+00:00"
+            "time": "2022-09-23T14:53:33+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -491,50 +491,6 @@ class Api
     }
 
     /**
-     * Return the user's projects.
-     *
-     * @param bool|null $refresh Whether to refresh the list of projects.
-     *
-     * @return Project[] The user's projects, keyed by project ID.
-     */
-    public function getProjects($refresh = null)
-    {
-        $cacheKey = sprintf('%s:projects', $this->config->getSessionId());
-
-        /** @var Project[] $projects */
-        $projects = [];
-
-        $cached = $this->cache->fetch($cacheKey);
-
-        if ($refresh === false && !$cached) {
-            return [];
-        } elseif ($refresh || !$cached) {
-            foreach ($this->getClient()->getProjects() as $project) {
-                $projects[$project->id] = $project;
-            }
-
-            $cachedProjects = [];
-            foreach ($projects as $id => $project) {
-                $cachedProjects[$id] = $project->getData();
-                $cachedProjects[$id]['_endpoint'] = $project->getUri(true);
-            }
-
-            $this->cache->save($cacheKey, $cachedProjects, (int) $this->config->get('api.projects_ttl'));
-        } else {
-            $guzzleClient = $this->getHttpClient();
-            $apiUrl = $this->config->getWithDefault('api.base_url', '');
-            foreach ((array) $cached as $id => $data) {
-                $projects[$id] = new Project($data, $data['_endpoint'], $guzzleClient);
-                if ($apiUrl) {
-                    $projects[$id]->setApiUrl($apiUrl);
-                }
-            }
-        }
-
-        return $projects;
-    }
-
-    /**
      * Returns the logged-in user's project stubs.
      *
      * @param bool $refresh
@@ -552,8 +508,7 @@ class Api
         if ($refresh === false && !$cached) {
             return [];
         } elseif ($refresh || !$cached) {
-            $data = $this->getClient()->getAccountInfo($refresh);
-            $stubs = ProjectStub::wrapCollection($data, $apiUrl, $guzzleClient);
+            $stubs = $this->getClient()->getProjectStubs((bool) $refresh);
             $cacheData = [
                 'projects' => array_map(function (ProjectStub $stub) { return $stub->getData(); }, $stubs)
             ];
@@ -576,19 +531,6 @@ class Api
      */
     public function getProject($id, $host = null, $refresh = null)
     {
-        // Find the project in the user's main project list. This uses a
-        // separate cache.
-        $projects = $this->getProjects($refresh);
-        if (isset($projects[$id]) && !$this->hostConflicts($projects[$id], $host)) {
-            $project = $projects[$id];
-            if ($apiUrl = $this->config->getWithDefault('api.base_url', '')) {
-                $project->setApiUrl($apiUrl);
-            }
-
-            return $project;
-        }
-
-        // Find the project directly.
         $cacheKey = sprintf('%s:project:%s:%s', $this->config->getSessionId(), $id, $host);
         $cached = $this->cache->fetch($cacheKey);
         if ($refresh || !$cached) {
@@ -927,7 +869,7 @@ class Api
      */
     public function clearProjectsCache()
     {
-        $this->cache->delete(sprintf('%s:projects', $this->config->getSessionId()));
+        $this->cache->delete(sprintf('%s:project-stubs', $this->config->getSessionId()));
         $this->cache->delete(sprintf('%s:my-account', $this->config->getSessionId()));
     }
 
@@ -1049,12 +991,12 @@ class Api
     /**
      * Returns a project label.
      *
-     * @param Project      $project
+     * @param Project|ProjectStub $project
      * @param string|false $tag
      *
      * @return string
      */
-    public function getProjectLabel(Project $project, $tag = 'info')
+    public function getProjectLabel($project, $tag = 'info')
     {
         $title = $project->title;
         $pattern = strlen($title) > 0 ? '%2$s (%3$s)' : '%3$s';


### PR DESCRIPTION
- Separate project "stub" from full project representations to avoid using the stub information accidentally. Fixes inconsistent marking a user as the project "owner" in the users:list (users) command.
- Fixes the validation error when asked for a project ID interactively.