### PR TITLE
Fix #1171: Autocompletion not working on Windows

### DIFF
--- a/src/Command/Self/SelfInstallCommand.php
+++ b/src/Command/Self/SelfInstallCommand.php
@@ -102,7 +102,7 @@ EOT
         try {
             $args = [
                 '--generate-hook' => true,
-                '--program' => $this->config()->get('application.executable'),
+                '--program' => '"' . $this->config()->get('application.executable') . '"',
             ];
             if ($shellType) {
                 $args['--shell-type'] = $shellType;


### PR DESCRIPTION
Add quotes around the application executable before passing it to the autocomplete hook script. 
Quoting prevents issues with the path when containing special characters (WS and/or `\`).