### PR TITLE
Fix autocompletion hook for program paths containing spaces

### DIFF
--- a/src/Command/Self/SelfInstallCommand.php
+++ b/src/Command/Self/SelfInstallCommand.php
@@ -101,8 +101,9 @@ EOT
         $this->stdErr->write('Setting up autocompletion...');
         try {
             $args = [
-                '--generate-hook' => true,
                 '--program' => $this->config()->get('application.executable'),
+                '--generate-hook' => true,
+                '--multiple' => true,
             ];
             if ($shellType) {
                 $args['--shell-type'] = $shellType;


### PR DESCRIPTION
Fixing #1171 as a possible alternative to #1174 