### PR TITLE
Fix inconsistency in variable:create between -e and --environment

### DIFF
--- a/src/Command/Variable/VariableCreateCommand.php
+++ b/src/Command/Variable/VariableCreateCommand.php
@@ -36,11 +36,6 @@ class VariableCreateCommand extends VariableCommandBase
     {
         $this->validateInput($input, true);
 
-        // Set the default for the environment form field.
-        if ($this->hasSelectedEnvironment() && ($field = $this->form->getField('environment'))) {
-            $field->set('default', $this->getSelectedEnvironment()->id);
-        }
-
         // Merge the 'name' argument with the --name option.
         if ($input->getArgument('name')) {
             if ($input->getOption('name')) {


### PR DESCRIPTION
Related to #1002

Awkwardly the "default" is compared with the value on the command line [here](https://github.com/platformsh/console-form/blob/d8f14e280a75098997cdfc562ae95392c7ee02f9/src/Field/Field.php#L500) using `getParameterOption('environment')`, which doesn't account for `-e`. Here `getParameterOption()` has to be used because `$input->getOption('environment')` (which _would_ account for `-e`) doesn't let you distinguish between "no value supplied, default used" and "default value explicitly supplied".

So, providing a default for the option causes the inconsistency between the short and long options. The solution is to stop providing a default. The result is that the --environment/-e value will be picked up anyway and then the question won't be shown.