### PR TITLE
Fix listing custom schema (database) names for postgresql

### DIFF
--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -76,13 +76,8 @@ class DbDumpCommand extends CommandBase
 
         $schema = $input->getOption('schema');
         if (empty($schema)) {
-            // Get a list of schemas from the service configuration.
-            $schemas = [];
-            if ($service) {
-                $schemas = !empty($service->configuration['schemas'])
-                    ? $service->configuration['schemas']
-                    : ['main'];
-            }
+            // Get a list of schemas (database names) from the service configuration.
+            $schemas = $service ? $relationships->getServiceSchemas($service) : [];
 
             // Filter the list by the schemas accessible from the endpoint.
             if (isset($database['rel'])

--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -101,16 +101,18 @@ class DbDumpCommand extends CommandBase
             }
 
             // Provide the user with a choice of schemas.
-            $choices = [];
             foreach ($schemas as $schema) {
                 $choices[$schema] = $schema;
                 if ($schema === $database['path']) {
                     $choices[$schema] .= ' (default)';
                 }
             }
-            /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
-            $questionHelper = $this->getService('question_helper');
-            $schema = $questionHelper->choose($choices, 'Enter a number to choose a schema:', $database['path'], true);
+            $schema = null;
+            if (!empty($choices)) {
+                /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+                $questionHelper = $this->getService('question_helper');
+                $schema = $questionHelper->choose($choices, 'Enter a number to choose a schema:', $database['path'], true);
+            }
             if (empty($schema)) {
                 $this->stdErr->writeln('The --schema is required.');
                 if (!empty($schemas)) {

--- a/src/Command/Db/DbSqlCommand.php
+++ b/src/Command/Db/DbSqlCommand.php
@@ -62,13 +62,8 @@ class DbSqlCommand extends CommandBase
                 $service = false;
             }
 
-            // Get a list of schemas from the service configuration.
-            $schemas = [];
-            if ($service) {
-                $schemas = !empty($service->configuration['schemas'])
-                    ? $service->configuration['schemas']
-                    : ['main'];
-            }
+            // Get a list of schemas (database names) from the service configuration.
+            $schemas = $service ? $relationships->getServiceSchemas($service) : [];
 
             // Filter the list by the schemas accessible from the endpoint.
             if (isset($database['rel'])

--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Query;
 use Platformsh\Cli\Model\Host\HostInterface;
 use Platformsh\Cli\Model\Host\LocalHost;
 use Platformsh\Cli\Util\OsUtil;
+use Platformsh\Client\Model\Deployment\Service;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -348,5 +349,24 @@ class Relationships implements InputConfiguringInterface
         }
 
         return \GuzzleHttp\Url::buildUrl($parts);
+    }
+
+    /**
+     * Returns a list of schemas (database names/paths) for a service.
+     *
+     * @return string[]
+     */
+    public function getServiceSchemas(Service $service)
+    {
+        if (!empty($service->configuration['schemas'])) {
+            return $service->configuration['schemas'];
+        }
+        if (!empty($service->configuration['databases'])) {
+            return $service->configuration['databases'];
+        }
+        if (preg_match('/^(postgresql|mariadb|mysql|oracle-mysql):/', $service->type) === 1) {
+            return ['main'];
+        }
+        return [];
     }
 }

--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -354,6 +354,15 @@ class Relationships implements InputConfiguringInterface
     /**
      * Returns a list of schemas (database names/paths) for a service.
      *
+     * The MySQL, MariaDB and Oracle MySQL services allow specifying custom
+     * schemas. The PostgreSQL service has the same feature, but they are
+     * unfortunately named differently: "databases" not "schemas". If nothing
+     * is configured, all four service types default to having one schema named
+     * "main".
+     *
+     * See https://docs.platform.sh/add-services/postgresql.html
+     * and https://docs.platform.sh/add-services/mysql.html
+     *
      * @return string[]
      */
     public function getServiceSchemas(Service $service)


### PR DESCRIPTION
The mysql/mariadb/oracle-mysql [services](https://docs.platform.sh/add-services/mysql.html) can be configured with custom `schemas`, which the CLI lists to find the default schema name for dumping a database in the `db:dump` command, if `--schema` is not supplied.

But the [postgresql](https://docs.platform.sh/add-services/postgresql.html) service is configured with custom `databases`, not `schemas`.