### PR TITLE
Ensure no-interaction and --yes behavior is consistent

### DIFF
--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -179,7 +179,7 @@ class DbDumpCommand extends CommandBase
 
         if ($dumpFile) {
             if (file_exists($dumpFile)) {
-                if (!$questionHelper->confirm("File exists: <comment>$dumpFile</comment>. Overwrite?", false)) {
+                if (!$questionHelper->confirm("File exists: <comment>$dumpFile</comment>. Overwrite?")) {
                     return 1;
                 }
             }

--- a/src/Command/Integration/IntegrationAddCommand.php
+++ b/src/Command/Integration/IntegrationAddCommand.php
@@ -68,7 +68,7 @@ class IntegrationAddCommand extends IntegrationCommandBase
                 "<comment>Warning:</comment> adding a '" . $values['type'] . "' integration will automatically synchronize code from the external Git repository."
                 . "\nThis means it can overwrite all the code in your project.\n"
             );
-            if (!$questionHelper->confirm('Are you sure you want to continue?', false)) {
+            if (!$questionHelper->confirm('Are you sure you want to continue?')) {
                 return 1;
             }
         }

--- a/src/Command/Local/LocalDrushAliasesCommand.php
+++ b/src/Command/Local/LocalDrushAliasesCommand.php
@@ -93,7 +93,7 @@ class LocalDrushAliasesCommand extends CommandBase
                 $existing = $drush->getAliases($new_group);
                 if (!empty($existing)) {
                     $question = "The Drush alias group <info>@$new_group</info> already exists. Overwrite?";
-                    if (!$questionHelper->confirm($question, false)) {
+                    if (!$questionHelper->confirm($question)) {
                         return 1;
                     }
                 }

--- a/src/Command/Project/ProjectSetRemoteCommand.php
+++ b/src/Command/Project/ProjectSetRemoteCommand.php
@@ -87,7 +87,7 @@ class ProjectSetRemoteCommand extends CommandBase
                 $this->stdErr->writeln(sprintf('These Git remote(s) will be deleted: <comment>%s</comment>', \implode(', ', \array_keys($gitRemotes))));
             }
             $this->stdErr->writeln('');
-            if (!$questionHelper->confirm('Are you sure?', false)) {
+            if (!$questionHelper->confirm('Are you sure?')) {
                 return 1;
             }
             foreach (array_keys($gitRemotes) as $gitRemote) {

--- a/src/Command/Service/MongoDB/MongoDumpCommand.php
+++ b/src/Command/Service/MongoDB/MongoDumpCommand.php
@@ -56,7 +56,7 @@ class MongoDumpCommand extends CommandBase
             if (file_exists($dumpFile)) {
                 /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
                 $questionHelper = $this->getService('question_helper');
-                if (!$questionHelper->confirm("File exists: <comment>$dumpFile</comment>. Overwrite?", false)) {
+                if (!$questionHelper->confirm("File exists: <comment>$dumpFile</comment>. Overwrite?")) {
                     return 1;
                 }
             }

--- a/src/Command/Tunnel/TunnelOpenCommand.php
+++ b/src/Command/Tunnel/TunnelOpenCommand.php
@@ -78,7 +78,7 @@ EOF
             /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
             $questionHelper = $this->getService('question_helper');
             $confirmText = \sprintf('Are you sure you want to open SSH tunnel(s) to the environment %s?', $this->api()->getEnvironmentLabel($environment, 'comment'));
-            if (!$questionHelper->confirm($confirmText, false)) {
+            if (!$questionHelper->confirm($confirmText)) {
                 return 1;
             }
             $this->stdErr->writeln('');

--- a/src/Command/Tunnel/TunnelSingleCommand.php
+++ b/src/Command/Tunnel/TunnelSingleCommand.php
@@ -65,7 +65,7 @@ class TunnelSingleCommand extends TunnelCommandBase
                 $service['_relationship_name'],
                 $this->api()->getEnvironmentLabel($environment, false)
             );
-            if (!$questionHelper->confirm($confirmText, false)) {
+            if (!$questionHelper->confirm($confirmText)) {
                 return 1;
             }
             $this->stdErr->writeln('');

--- a/src/Service/QuestionHelper.php
+++ b/src/Service/QuestionHelper.php
@@ -39,8 +39,10 @@ class QuestionHelper extends BaseQuestionHelper
     /**
      * Ask the user to confirm an action.
      *
-     * @param string          $questionText
-     * @param bool            $default
+     * @param string $questionText
+     * @param bool   $default
+     *   The default answer. Warning: this should be left as true if the question is going to be used in non-interactive
+     *   mode. This keeps consistent behavior for the --no-interaction and --yes (-y) options.
      *
      * @return bool
      */


### PR DESCRIPTION
Interaction can be turned off under the PLATFORMSH_CLI_NO_INTERACTION=1 environment variable, or the --yes or --no options. The --yes option picks the default answer for all prompts, except for "confirmation" prompts where it always answers "yes". However, the environment variable picks the default answer for all prompts _including_ confirmation questions, which so far could have a default answer of yes _or_ no.

This commit keeps the same meaning for those options but makes the two behaviors consistent by ensuring that confirmation questions always have the default of "yes" when shown in non-interactive mode.

Relates to both #1054 and #1182 