### PR TITLE
Support slash style branches.

### DIFF
--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -101,7 +101,9 @@ class Git
     {
         $args = ['symbolic-ref', '--short', 'HEAD'];
 
-        return $this->execute($args, $dir, $mustRun);
+        $branch = $this->execute($args, $dir, $mustRun);
+
+        return str_replace('/', '-', $branch);
     }
 
     /**


### PR DESCRIPTION
Currenly if there a slash in branch name like `feature/feature-name` the cli can not find the relevant git branch. 

Since git replaces the `/`  in branch name with `-` - we can easily do the same replacement and make it work for branches with slashes.