### PR TITLE
Avoid a TypeError when reading invalid applications.yaml configuration

### DIFF
--- a/src/Command/Environment/EnvironmentXdebugCommand.php
+++ b/src/Command/Environment/EnvironmentXdebugCommand.php
@@ -37,7 +37,8 @@ class EnvironmentXdebugCommand extends CommandBase
             try {
                 return !$this->isPhp($projectRoot);
             } catch (\Exception $e) {
-                // Ignore errors when loading or parsing configuration.
+                // Warn but otherwise ignore errors when loading or parsing configuration.
+                trigger_error($e->getMessage(), E_USER_WARNING);
                 return true;
             }
         }

--- a/src/Local/ApplicationFinder.php
+++ b/src/Local/ApplicationFinder.php
@@ -88,6 +88,10 @@ class ApplicationFinder
         $applications = [];
         $appConfigs = (array) (new YamlParser())->parseFile($configFile);
         foreach ($appConfigs as $key => $appConfig) {
+            if (!is_array($appConfig)) {
+                $type = gettype($appConfig);
+                throw new InvalidConfigException("Application config has invalid type $type: it must be an object", $configFile, $key);
+            }
             $appRoot = $this->getExplicitRoot($appConfig, $directory);
             if ($appRoot === null) {
                 throw new InvalidConfigException('The "source.root" key is required', $configFile, $key);


### PR DESCRIPTION
Closes #1190 

A PHP 8 TypeError is being thrown when applications.yaml holds configuration of the wrong type (an application must be an object). The error is not an \Exception so it cannot easily be caught in the PHP < 7 compatible logic for hiding the Xdebug command when the project is not PHP. This PR makes the error an InvalidConfigException.