### PR TITLE
Help users migrate to the new CLI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -61,6 +61,10 @@ application:
   disabled_commands:
     - auth:password-login
 
+  wrapped_disabled_commands:
+    - self:install
+    - self:update
+
   # Experimental commands (a list of full command names). Enable these in the
   # user config file: the array 'enable_commands' inside the 'experimental'
   # section.
@@ -226,3 +230,7 @@ updates:
 
   # Overridden by {application.env_prefix}UPDATES_CHECK env var.
   check: true
+
+migrate:
+  prompt: true
+  docs_url: https://docs.platform.sh/administration/cli.html

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -297,7 +297,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
 
         $this->checkUpdates();
         $this->checkSelfInstall();
-        // Run migration steps only for the Platform.sh CLI
+        // Run migration steps if configured.
         if ($this->config()->getWithDefault('migrate.prompt', false)) {
             $this->checkBothCLIsInstalled();
             $this->checkMigrateToNewCLI();

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -446,6 +446,11 @@ class Config
             && in_array($name, $this->config['application']['disabled_commands'])) {
             return false;
         }
+        if ($this->isWrapped()
+            && !empty($this->config['application']['wrapped_disabled_commands'])
+            && in_array($name, $this->config['application']['wrapped_disabled_commands'])) {
+            return false;
+        }
         if (!empty($this->config['application']['experimental_commands'])
             && in_array($name, $this->config['application']['experimental_commands'])) {
             return !empty($this->config['experimental']['all_experiments'])
@@ -568,5 +573,15 @@ class Config
         }
 
         return $opts;
+    }
+
+    /**
+     * Detects if the CLI is running wrapped inside the go wrapper.
+     *
+     * @return bool
+     */
+    public function isWrapped()
+    {
+        return getenv($this->get('application.env_prefix') . 'WRAPPED') === '1';
     }
 }

--- a/src/Util/OsUtil.php
+++ b/src/Util/OsUtil.php
@@ -71,4 +71,38 @@ class OsUtil
 
         return '"' . str_replace(['"', '^', '%', '!', "\n"], ['""', '"^^"', '"^%"', '"^!"', '!LF!'], $argument) . '"';
     }
+
+    /**
+     * Finds all executable matching the given name inside the PATH.
+     *
+     * @see \Symfony\Component\Process\ExecutableFinder::find()
+     *
+     * @param string $name
+     *
+     * @return array
+     */
+    public static function findExecutables($name)
+    {
+        $dirs = explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path'));
+        $suffixes = [''];
+
+        $found = [];
+
+        $isWindows = self::isWindows();
+        if ($isWindows) {
+            $suffixes = ['.exe', '.bat', '.cmd', '.com'];
+            $pathExt = getenv('PATHEXT');
+            $suffixes = array_merge($pathExt ? explode(\PATH_SEPARATOR, $pathExt) : $suffixes, $suffixes);
+        }
+
+        foreach ($suffixes as $suffix) {
+            foreach ($dirs as $dir) {
+                if (@is_file($file = $dir.\DIRECTORY_SEPARATOR.$name.$suffix) && ($isWindows || @is_executable($file))) {
+                    array_push($found, $file);
+                }
+            }
+        }
+
+        return $found;
+    }
 }


### PR DESCRIPTION
* Add notification if both CLIs are installed
      If the user has both the New CLI and the Legacy CLI installed and the Legacy CLI has execution precendence because of the `PATH` config, a warning is displayed.
* Add migrate prompt for the new CLI
  The migrate prompt is disabled in the following cases:
  * CLIs for white-labels other than Platform.sh
  * CI systems
  * When the CLI is run in the new wrapper
* Better use config for custom Wrapped functionality